### PR TITLE
chore: configure renovate semantic commit format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,7 @@
       "groupName": "OpenCensus packages"
     }
   ],
+  "prHourlyLimit": 5,
   "semanticCommits": true,
   "semanticPrefix": "deps"
 }


### PR DESCRIPTION
This should force renovate to create the commit and PR as `deps: update X to Y`