### PR TITLE
fix: activate release profile via performRelease property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,11 @@
   <profiles>
     <profile>
       <id>release</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Allows you to specify `-DperformRelease=true` or `-Prelease` to activate the release profile