### PR TITLE
build: add autovalue profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,5 +406,43 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>autovalue-java7</id>
+      <activation>
+        <jdk>1.7</jdk>
+      </activation>
+      <properties>
+        <autovalue.version>1.4</autovalue.version>
+      </properties>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${autovalue.version}</version>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+    <profile>
+      <id>autovalue-java8</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <autovalue.version>1.6.6</autovalue.version>
+      </properties>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${autovalue.version}</version>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
There are versions of `com.google.auto.value:auto-value` needed when
running on java7 vs java8+, to address this we define profiles that
have jdk based activation criteria.
