### PR TITLE
feat: enable clirr-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,11 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>clirr-maven-plugin</artifactId>
+          <version>2.8</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -296,6 +301,21 @@
                 </resource>
               </resources>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <ignoredDifferencesFile>clirr-ignored-differences.xml</ignoredDifferencesFile>
+          <logResults>true</logResults>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This plugin checks binary/source compatibility. You can override the checks by adding/modifying the `clirr-ignored-differences.xml` file in the artifact root directory.