### PR TITLE
feat: add profile which allows the use of snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,21 @@
         </plugins>
       </build>
     </profile>
-
+    <profile>
+      <id>allow-snapshots</id>
+      <repositories>
+        <repository>
+          <id>sonatype-snapshots</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
     <profile>
       <!-- Only run checkstyle plugin on Java 8+ (checkstyle artifact only supports Java 8+) -->
       <id>checkstyle-tests</id>


### PR DESCRIPTION
In the downstream project you can add `-Pallow-snapshots` which allow fetching dependencies from Sonatype's snapshot repository.