### PR TITLE
build: add reporting section for site definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Template values used in site generation -->
+    <site.installationModule>${project.artifactId}</site.installationModule>
+    <report.jxr.inherited>false</report.jxr.inherited>
   </properties>
 
   <build>
@@ -336,6 +339,97 @@
       </plugin>
     </plugins>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>dependency-info</report>
+              <report>team</report>
+              <report>ci-management</report>
+              <report>issue-management</report>
+              <report>licenses</report>
+              <report>scm</report>
+              <report>dependency-management</report>
+              <report>distribution-management</report>
+              <report>summary</report>
+              <report>modules</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+        <configuration>
+          <dependencyDetailsEnabled>true</dependencyDetailsEnabled>
+          <artifactId>${site.installationModule}</artifactId>
+          <packaging>jar</packaging>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+        <reportSets>
+          <reportSet>
+            <id>html</id>
+            <reports>
+              <report>javadoc</report>
+              <report>aggregate</report>
+              <report>aggregate-jar</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+        <configuration>
+          <doclint>none</doclint>
+          <show>protected</show>
+          <nohelp>true</nohelp>
+          <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
+          <groups>
+            <group>
+              <title>Test helpers packages</title>
+              <packages>com.google.cloud.testing</packages>
+            </group>
+            <group>
+              <title>SPI packages</title>
+              <packages>com.google.cloud.spi*</packages>
+            </group>
+          </groups>
+
+          <links>
+            <link>https://googleapis.dev/java/api-common/</link>
+            <link>https://googleapis.dev/java/gax/</link>
+            <link>https://googleapis.dev/java/google-auth-library/</link>
+
+            <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
+            <link>https://googleapis.github.io/common-protos-java/apidocs/</link>
+            <link>https://grpc.io/grpc-java/javadoc/</link>
+          </links>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <linkJavadoc>true</linkJavadoc>
+        </configuration>
+        <reportSets>
+          <reportSet>
+            <id>aggregate</id>
+            <inherited>${report.jxr.inherited}</inherited>
+            <reports>
+              <report>jxr</report>
+              <report>aggregate</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
 
   <profiles>
     <profile>


### PR DESCRIPTION
Add reporting plugin configuration for javadoc, JXR and info reports.

Javadoc:
Configuration values for javadoc generation including groups and links
* javadoc - per module javadoc generation
* aggregate - aggregate all modules in a multi-module project into a
  single site
* aggregate-jar - same as aggregate but jar all the generated files

JXR:
Site report that includes all source code in the package (including
any generated code)
* jxr report - per module
* aggregate report - aggregates for multi-module projects
