### PR TITLE
fix: remove autovalue profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,43 +556,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>autovalue-java7</id>
-      <activation>
-        <jdk>1.7</jdk>
-      </activation>
-      <properties>
-        <autovalue.version>1.4</autovalue.version>
-      </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>${autovalue.version}</version>
-            <scope>provided</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-    </profile>
-    <profile>
-      <id>autovalue-java8</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <autovalue.version>1.6.6</autovalue.version>
-      </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>${autovalue.version}</version>
-            <scope>provided</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
autovalue should be configured via annotation processors rather than as a dependency.
Additionally, it should be only configured for relevant projects.

Fixes #61 