### PR TITLE
feat: add new enable-integration-tests profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <!-- Template values used in site generation -->
     <site.installationModule>${project.artifactId}</site.installationModule>
     <report.jxr.inherited>false</report.jxr.inherited>
+    <skipITs>true</skipITs>
   </properties>
 
   <build>
@@ -555,6 +556,12 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>enable-integration-tests</id>
+      <properties>
+        <skipITs>false</skipITs>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Integration tests generally require credentials and access to external
GCP services which is not always available to every contributor.

This change skips the running of integration tests by default (they are
still compiled) in favor of explicitly enabling. To enable the running
of integration tests activate the `enable-integration-tests` profile
when executing maven (command line are: `-Penable-integration-tests`)

Depends on https://github.com/googleapis/synthtool/pull/350 being merged
and projects having their autosynth PRs being merged.