### PR TITLE
fix: use surefire-junit47 provider for surefire/failsafe plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
-              <artifactId>surefire-junit4</artifactId>
+              <artifactId>surefire-junit47</artifactId>
               <version>3.0.0-M4</version>
             </dependency>
           </dependencies>
@@ -128,7 +128,7 @@
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
-              <artifactId>surefire-junit4</artifactId>
+              <artifactId>surefire-junit47</artifactId>
               <version>3.0.0-M4</version>
             </dependency>
           </dependencies>


### PR DESCRIPTION
Spanner tests use the grouping feature of tests and require using the junit47 provider for running the tests.

If we leave the junit4 provider in the shared-config and specify the junit47 provider downstream in the spanner repo, then tests run twice - once for each provider. The junit4 provider will not skip tests annotated as integration tests while running unit tests and will fail.