### PR TITLE
fix: declare com.coveo:fmt-maven-plugin version/configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,15 @@
           <artifactId>clirr-maven-plugin</artifactId>
           <version>2.8</version>
         </plugin>
+        <plugin>
+          <groupId>com.coveo</groupId>
+          <artifactId>fmt-maven-plugin</artifactId>
+          <version>2.9</version>
+          <configuration>
+            <style>google</style>
+            <verbose>true</verbose>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
We should explicitly declare the formatter plugin version/options.