### PR TITLE
chore: only allow renovate-bot for trusted-contribution auto-labeling

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,2 @@
+trustedContributors:
+- renovate-bot


### PR DESCRIPTION
We want to only run release-please tests when we're ready to release.