### PR TITLE
feat: add Devsite Javadoc profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -616,7 +616,7 @@
                 <additionalOption>/java/_book.yaml</additionalOption>
                 <additionalOption>-hdf</additionalOption>
                 <additionalOption>project.path</additionalOption>
-                <additionalOption>/_project.yaml</additionalOption>
+                <additionalOption>/java/_project.yaml</additionalOption>
                 <additionalOption>-hdf</additionalOption>
                 <additionalOption>devsite.path</additionalOption>
                 <additionalOption>/java/docs/reference/</additionalOption>

--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,6 @@
                     <delete file="${project.build.directory}/devsite/reference/hierarchy.html" />
                     <delete file="${project.build.directory}/devsite/reference/index.html" />
                     <delete file="${project.build.directory}/devsite/reference/lists.js" />
-                    <delete file="${project.build.directory}/devsite/reference/package-list" />
                     <delete file="${project.build.directory}/devsite/reference/packages.html" />
                     <delete file="${project.build.directory}/devsite/reference/current.xml" />
                   </target>

--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,7 @@
       <id>devsite-apidocs</id>
       <activation>
         <property>
+          <!-- Activate with the -Ddevsite.template=/path/to/templates flag. -->
           <name>devsite.template</name>
         </property>
       </activation>
@@ -620,7 +621,7 @@
                 <additionalOption>devsite.path</additionalOption>
                 <additionalOption>/java/docs/reference/</additionalOption>
                 <additionalOption>-d</additionalOption>
-                <additionalOption>${project.build.directory}/apidocs</additionalOption>
+                <additionalOption>${project.build.directory}/devsite</additionalOption>
                 <additionalOption>-templatedir</additionalOption>
                 <additionalOption>${devsite.template}</additionalOption>
                 <additionalOption>-toroot</additionalOption>
@@ -631,7 +632,6 @@
                 <additionalOption>101</additionalOption>
               </additionalOptions>
               <useStandardDocletOptions>false</useStandardDocletOptions>
-              <additionalJOption>-J-Xmx1024m</additionalJOption>
             </configuration>
           </plugin>
           <plugin>
@@ -647,15 +647,19 @@
                 <configuration>
                   <target>
                     <echo message="Updating relative links in API docs" />
-                    <replace dir="${project.build.directory}/apidocs" token="href=&quot;com" value="href=&quot;/java/docs/reference/com" />
-                    <copy file="${project.build.directory}/apidocs/assets/_toc.yaml" todir="${project.build.directory}/apidocs/reference" />
-                    <delete file="${project.build.directory}/apidocs/reference/classes.html" />
-                    <delete file="${project.build.directory}/apidocs/reference/hierarchy.html" />
-                    <delete file="${project.build.directory}/apidocs/reference/index.html" />
-                    <delete file="${project.build.directory}/apidocs/reference/lists.js" />
-                    <delete file="${project.build.directory}/apidocs/reference/package-list" />
-                    <delete file="${project.build.directory}/apidocs/reference/packages.html" />
-                    <delete file="${project.build.directory}/apidocs/reference/current.xml" />
+                    <!-- TODO: What is the right behavior for io* and google*? -->
+                    <replace dir="${project.build.directory}/devsite" token="href=&quot;com" value="href=&quot;/java/docs/reference/com" />
+                    <replace dir="${project.build.directory}/devsite" token="href=&quot;io" value="href=&quot;/java/docs/reference/io" />
+                    <replace dir="${project.build.directory}/devsite" token="href=&quot;google" value="href=&quot;/java/docs/reference/google" />
+                    <copy file="${project.build.directory}/devsite/assets/_toc.yaml" todir="${project.build.directory}/devsite/reference" />
+                    <echo message="Removing files not needed by Devsite" />
+                    <delete file="${project.build.directory}/devsite/reference/classes.html" />
+                    <delete file="${project.build.directory}/devsite/reference/hierarchy.html" />
+                    <delete file="${project.build.directory}/devsite/reference/index.html" />
+                    <delete file="${project.build.directory}/devsite/reference/lists.js" />
+                    <delete file="${project.build.directory}/devsite/reference/package-list" />
+                    <delete file="${project.build.directory}/devsite/reference/packages.html" />
+                    <delete file="${project.build.directory}/devsite/reference/current.xml" />
                   </target>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -619,13 +619,13 @@
                 <additionalOption>/java/_project.yaml</additionalOption>
                 <additionalOption>-hdf</additionalOption>
                 <additionalOption>devsite.path</additionalOption>
-                <additionalOption>/java/docs/reference/</additionalOption>
+                <additionalOption>/java/reference/</additionalOption>
                 <additionalOption>-d</additionalOption>
                 <additionalOption>${project.build.directory}/devsite</additionalOption>
                 <additionalOption>-templatedir</additionalOption>
                 <additionalOption>${devsite.template}</additionalOption>
                 <additionalOption>-toroot</additionalOption>
-                <additionalOption>/java/docs/reference/</additionalOption>
+                <additionalOption>/java/reference/</additionalOption>
                 <additionalOption>-yaml</additionalOption>
                 <additionalOption>_toc.yaml</additionalOption>
                 <additionalOption>-warning</additionalOption>
@@ -648,9 +648,9 @@
                   <target>
                     <echo message="Updating relative links in API docs" />
                     <!-- TODO: What is the right behavior for io* and google*? -->
-                    <replace dir="${project.build.directory}/devsite" token="href=&quot;com" value="href=&quot;/java/docs/reference/com" />
-                    <replace dir="${project.build.directory}/devsite" token="href=&quot;io" value="href=&quot;/java/docs/reference/io" />
-                    <replace dir="${project.build.directory}/devsite" token="href=&quot;google" value="href=&quot;/java/docs/reference/google" />
+                    <replace dir="${project.build.directory}/devsite" token="href=&quot;com" value="href=&quot;/java/reference/com" />
+                    <replace dir="${project.build.directory}/devsite" token="href=&quot;io" value="href=&quot;/java/reference/io" />
+                    <replace dir="${project.build.directory}/devsite" token="href=&quot;google" value="href=&quot;/java/reference/google" />
                     <copy file="${project.build.directory}/devsite/assets/_toc.yaml" todir="${project.build.directory}/devsite/reference" />
                     <echo message="Removing files not needed by Devsite" />
                     <delete file="${project.build.directory}/devsite/reference/classes.html" />

--- a/pom.xml
+++ b/pom.xml
@@ -572,5 +572,97 @@
         <skipITs>false</skipITs>
       </properties>
     </profile>
+    <profile>
+      <id>devsite-apidocs</id>
+      <activation>
+        <property>
+          <name>devsite.template</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- Generate API docs using Doclava for the developer site. -->
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <!-- Note: version 3.x.x uses additionalOption instead of additionalparam. -->
+            <version>3.1.1</version>
+            <executions>
+              <execution>
+                <phase>site</phase>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <docletArtifact>
+                <groupId>com.google.doclava</groupId>
+                <artifactId>doclava</artifactId>
+                <version>1.0.6</version>
+              </docletArtifact>
+              <doclet>com.google.doclava.Doclava</doclet>
+              <bootclasspath>${sun.boot.class.path}</bootclasspath>
+              <additionalDependencies>
+                <additionalDependency>
+                  <groupId>com.google.j2objc</groupId>
+                  <artifactId>j2objc-annotations</artifactId>
+                  <version>1.3</version>
+                </additionalDependency>
+              </additionalDependencies>
+              <additionalOptions>
+                <additionalOption>-hdf</additionalOption>
+                <additionalOption>book.path</additionalOption>
+                <additionalOption>/java/_book.yaml</additionalOption>
+                <additionalOption>-hdf</additionalOption>
+                <additionalOption>project.path</additionalOption>
+                <additionalOption>/_project.yaml</additionalOption>
+                <additionalOption>-hdf</additionalOption>
+                <additionalOption>devsite.path</additionalOption>
+                <additionalOption>/java/docs/reference/</additionalOption>
+                <additionalOption>-d</additionalOption>
+                <additionalOption>${project.build.directory}/apidocs</additionalOption>
+                <additionalOption>-templatedir</additionalOption>
+                <additionalOption>${devsite.template}</additionalOption>
+                <additionalOption>-toroot</additionalOption>
+                <additionalOption>/java/docs/reference/</additionalOption>
+                <additionalOption>-yaml</additionalOption>
+                <additionalOption>_toc.yaml</additionalOption>
+                <additionalOption>-warning</additionalOption>
+                <additionalOption>101</additionalOption>
+              </additionalOptions>
+              <useStandardDocletOptions>false</useStandardDocletOptions>
+              <additionalJOption>-J-Xmx1024m</additionalJOption>
+            </configuration>
+          </plugin>
+          <plugin>
+            <!-- Clean up some references and files. -->
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <phase>site</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo message="Updating relative links in API docs" />
+                    <replace dir="${project.build.directory}/apidocs" token="href=&quot;com" value="href=&quot;/java/docs/reference/com" />
+                    <copy file="${project.build.directory}/apidocs/assets/_toc.yaml" todir="${project.build.directory}/apidocs/reference" />
+                    <delete file="${project.build.directory}/apidocs/reference/classes.html" />
+                    <delete file="${project.build.directory}/apidocs/reference/hierarchy.html" />
+                    <delete file="${project.build.directory}/apidocs/reference/index.html" />
+                    <delete file="${project.build.directory}/apidocs/reference/lists.js" />
+                    <delete file="${project.build.directory}/apidocs/reference/package-list" />
+                    <delete file="${project.build.directory}/apidocs/reference/packages.html" />
+                    <delete file="${project.build.directory}/apidocs/reference/current.xml" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
I'm not sure the best way to test this. I tried activating the profile, but it doesn't work because there are no packages to generate docs for, so the `antrun` `replace` and `copy` steps fail.

I copied this from prototypes for java-vision and java-bigtable, which worked.