### PR TITLE
feat: revert "feat: mark auto-value-annotations scope as provided"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,8 +506,6 @@
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value-annotations</artifactId>
         <version>${auto-value-annotation.version}</version>
-        <!-- Marking scope as provided per sync up w AutoValue creator-->
-        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
due to discrepancies in dependency:list resolving >1 level provided transitive deps vs. flatten plugin flattendenpendencymode==all