### PR TITLE
fix: bump flatten plugin version to fix missing version in profile s…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.2.2</version>
+          <version>1.2.3</version>
           <executions>
             <!-- enable flattening -->
             <execution>


### PR DESCRIPTION
Fixes issue previously observed where `<version>` was not parsed in `<profile>`
