### PR TITLE
feat: add ignore rule for javax annotations to handle error in java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.1.2</version>
+          <configuration>
+            <ignoredUnusedDeclaredDependencies>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependencies>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
to unblock googleapis/synthtool@4f2c9f7 change since dependency:analyze does not handle transitive used dependencies and now we're using flatten plugin 