### PR TITLE
fix: maven-dependency-plugin configuration breaking downstream config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,9 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.1.2</version>
           <configuration>
-            <ignoredUnusedDeclaredDependencies>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependencies>
+              <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
+            </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
When providing configuration to the maven-dependency-plugin,
`ignoredUnusedDeclaredDependencies` is a `java.lang.String[]` but mavens xml
handling allows multiple formats for providing a list of values (comma
separated string, or sub elements each specifying a single value). It appears
that when loading the config, the value of the configuration at a lower level
is blindly pre-pended as a string rather than first parsing and merging the
results. Below is the debug output of the resolved configuration using the
existing config added in cd635ad6, the output after this change and a diff of
the two. Notice, in the left hand side of the diff the malformed xml.

The change introduced in this commit switches from using the comma separated
string representation, to using the sub element representation thereby allowing
the config resolution to create a valid config.

###### Resolved config as of cd635ad6
```
[DEBUG] Goal:          org.apache.maven.plugins:maven-dependency-plugin:3.1.2:analyze (default-cli)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <analyzer default-value="default">${analyzer}</analyzer>
  <baseDir default-value="${basedir}"/>
  <failOnWarning default-value="false">${failOnWarning}</failOnWarning>
  <ignoreNonCompile default-value="false">${ignoreNonCompile}</ignoreNonCompile>
  <ignoredUnusedDeclaredDependencies>
    <ignoredUnusedDeclaredDependency>com.google.http-client:google-http-client-jackson2</ignoredUnusedDeclaredDependency>
    <ignoredUnusedDeclaredDependency>com.google.oauth-client:google-oauth-client</ignoredUnusedDeclaredDependency>
    <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependencies>
  <outputDirectory default-value="${project.build.directory}"/>
  <outputXML default-value="false">${outputXML}</outputXML>
  <project default-value="${project}"/>
  <scriptableFlag default-value="$$$%%%">${scriptableFlag}</scriptableFlag>
  <scriptableOutput default-value="false">${scriptableOutput}</scriptableOutput>
  <skip default-value="false">${mdep.analyze.skip}</skip>
  <verbose default-value="false">${verbose}</verbose>
</configuration>
```

###### Resolved config now
```
[DEBUG] Goal:          org.apache.maven.plugins:maven-dependency-plugin:3.1.2:analyze (default-cli)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <analyzer default-value="default">${analyzer}</analyzer>
  <baseDir default-value="${basedir}"/>
  <failOnWarning default-value="false">${failOnWarning}</failOnWarning>
  <ignoreNonCompile default-value="false">${ignoreNonCompile}</ignoreNonCompile>
  <ignoredUnusedDeclaredDependencies>
    <ignoredUnusedDeclaredDependency>com.google.http-client:google-http-client-jackson2</ignoredUnusedDeclaredDependency>
    <ignoredUnusedDeclaredDependency>com.google.oauth-client:google-oauth-client</ignoredUnusedDeclaredDependency>
    <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
  </ignoredUnusedDeclaredDependencies>
  <outputDirectory default-value="${project.build.directory}"/>
  <outputXML default-value="false">${outputXML}</outputXML>
  <project default-value="${project}"/>
  <scriptableFlag default-value="$$$%%%">${scriptableFlag}</scriptableFlag>
  <scriptableOutput default-value="false">${scriptableOutput}</scriptableOutput>
  <skip default-value="false">${mdep.analyze.skip}</skip>
  <verbose default-value="false">${verbose}</verbose>
</configuration>

```

##### Diff between resolved configs
```diff
12c12,13
<     <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependencies>
---
>     <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
>   </ignoredUnusedDeclaredDependencies>
```
