### PR TITLE
chore: fix maven warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -680,7 +680,7 @@
               <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.0.jar</docletPath>
-              <additionalOptions>-outputpath ${project.build.directory}/docfx-yml -projectname ${artifactId}</additionalOptions>
+              <additionalOptions>-outputpath ${project.build.directory}/docfx-yml -projectname ${project.artifactId}</additionalOptions>
               <doclint>none</doclint>
               <show>protected</show>
               <nohelp>true</nohelp>


### PR DESCRIPTION
This should fix the warnings " The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead."
