### PR TITLE
Revert "build(deps): update dependency com.coveo:fmt-maven-plugin to v2.12"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <plugin>
           <groupId>com.coveo</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.12</version>
+          <version>2.9</version>
           <configuration>
             <style>google</style>
             <verbose>true</verbose>


### PR DESCRIPTION
Reverts googleapis/java-shared-config#300

Version v2.12 merged in #300 is not compatible with google-java-format v1.7 due to a missing API. google-java-format v1.7 is necessary for java 8 compatibility. 
```
com.google.googlejavaformat.java.ImportOrderer.reorderImports(Ljava/lang/String;Lcom/google/googlejavaformat/java/JavaFormatterOptions$Style;)Ljava/lang/String;
```
