### PR TITLE
fix: update java docfx doclet version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -698,7 +698,7 @@
             <configuration>
               <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
               <useStandardDocletOptions>false</useStandardDocletOptions>
-              <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.1.1.jar</docletPath>
+              <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.2.0.jar</docletPath>
               <additionalOptions>-outputpath ${project.build.directory}/docfx-yml -projectname ${project.artifactId}</additionalOptions>
               <doclint>none</doclint>
               <show>protected</show>


### PR DESCRIPTION
- https://github.com/googleapis/java-docfx-doclet/releases/tag/1.2.0
- doclet jar has already been uploaded to bucket cloud-devrel-kokoro-resources/docfx
- Updates adds status fields and package-summary to toc

Fixes b/195424727, b/194728230 

