### PR TITLE
fix: update doclet version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,7 +699,7 @@
             <configuration>
               <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
               <useStandardDocletOptions>false</useStandardDocletOptions>
-              <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.2.1.jar</docletPath>
+              <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.3.0.jar</docletPath>
               <additionalOptions>-outputpath ${project.build.directory}/docfx-yml -projectname ${project.artifactId}</additionalOptions>
               <doclint>none</doclint>
               <show>protected</show>


### PR DESCRIPTION
bumps java-docfx-doclet version to incorporate new doclet [updates](https://github.com/googleapis/java-docfx-doclet/releases/tag/1.3.0)

doclet jar has already been tested and uploaded to cloud-devrel-kokoro-resources/docfx
