### PR TITLE
fix(java): downgrade native maven plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -800,7 +800,8 @@
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
-          <version>0.9.6</version>
+          <!-- Must be version 0.9.5 -->
+          <version>0.9.5</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -821,7 +822,8 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>0.9.6</version>
+            <!-- Must be version 0.9.5 -->
+            <version>0.9.5</version>
             <executions>
               <execution>
                 <id>test-native</id>

--- a/pom.xml
+++ b/pom.xml
@@ -800,7 +800,7 @@
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
-          <!-- Using older version; upgrade to latest once issues are resolved. -->
+          <!-- Using older version; upgrade to latest once issues are resolved. See #336 -->
           <version>0.9.5</version>
           <scope>test</scope>
         </dependency>
@@ -822,7 +822,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <!-- Using older version; upgrade to latest once issues are resolved. -->
+            <!-- Using older version; upgrade to latest once issues are resolved. See #336. -->
             <version>0.9.5</version>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -800,7 +800,7 @@
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
-          <!-- Must be version 0.9.5 -->
+          <!-- Using older version; upgrade to latest once issues are resolved. -->
           <version>0.9.5</version>
           <scope>test</scope>
         </dependency>
@@ -822,7 +822,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <!-- Must be version 0.9.5 -->
+            <!-- Using older version; upgrade to latest once issues are resolved. -->
             <version>0.9.5</version>
             <executions>
               <execution>


### PR DESCRIPTION
Temporarily downgrades the `native-maven-plugin` version from `0.9.6` to `0.9.5`; the latest version breaks for our project. Currently investigating root cause.