### PR TITLE
chore: cleanup cloud RAD generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -673,62 +673,52 @@
     </profile>
 
     <profile>
+      <!-- cloud RAD generation -->
       <id>docFX</id>
       <activation>
         <property>
-          <!-- Activate with -P docFX -->
+          <!-- activate with -P docFX -->
           <name>docFX</name>
         </property>
       </activation>
-      <reporting>
+      <properties>
+        <!-- default config values -->
+        <docletName>java-docfx-doclet-1.3.0</docletName>
+        <outputpath>${project.build.directory}/docfx-yml</outputpath>
+        <projectname>${project.artifactId}</projectname>
+        <excludeclasses></excludeclasses>
+        <excludePackages></excludePackages>
+        <source>8</source>            
+        <sourceFileExclude></sourceFileExclude>
+      </properties>
+      <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.3.1</version>
-            <reportSets>
-              <reportSet>
-                <id>docFX</id>
-                <reports>
-                  <report>javadoc</report>
-                  <report>aggregate</report>
-                  <report>aggregate-jar</report>
-                </reports>
-              </reportSet>
-            </reportSets>
             <configuration>
               <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
               <useStandardDocletOptions>false</useStandardDocletOptions>
-              <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.3.0.jar</docletPath>
-              <additionalOptions>-outputpath ${project.build.directory}/docfx-yml -projectname ${project.artifactId}</additionalOptions>
+               <!-- custom config with -Dproperty=value -->
+              <docletPath>${env.KOKORO_GFILE_DIR}/${docletName}.jar</docletPath>
+              <additionalOptions>
+                -outputpath ${outputpath} 
+                -projectname ${projectname} 
+                -excludeclasses ${excludeclasses}: 
+                -excludepackages ${excludePackages}:
+              </additionalOptions>
               <doclint>none</doclint>
               <show>protected</show>
               <nohelp>true</nohelp>
-              <groups>
-                <group>
-                  <title>Test helpers packages</title>
-                  <packages>com.google.cloud.testing</packages>
-                </group>
-                <group>
-                  <title>SPI packages</title>
-                  <packages>com.google.cloud.spi*</packages>
-                </group>
-              </groups>
-              <links>
-                <link>https://googleapis.dev/java/api-common/latest/</link>
-                <link>https://googleapis.dev/java/gax/latest/</link>
-                <link>https://googleapis.dev/java/google-auth-library/latest/</link>
-                <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
-                <link>https://googleapis.github.io/common-protos-java/apidocs/</link>
-                <link>https://googleapis.github.io/api-common-java/apidocs/</link>
-                <link>https://grpc.io/grpc-java/javadoc/</link>
-                <link>https://docs.oracle.com/javase/8/docs/api/</link>
-              </links>
+              <source>${source}</source>
+              <sourceFileExcludes>
+                <exclude>${sourceFileExclude}</exclude>
+              </sourceFileExcludes>
             </configuration>
-
           </plugin>
         </plugins>
-      </reporting>
+      </build>
     </profile>
     
     <profile>


### PR DESCRIPTION
- moving from \<reporting> to \<build> - will generate faster since we don't need the reports, but will now need to use command `mvn javadoc:aggregate -P docFX` instead of `mvn site -P docFX` to generate yaml
- setting up config as properties - will default to values in \<properties> section or can provide config via command with `-Dproperty=value` which helps us with regeneration
- removing \<groups> and \<links> sections which aren't doing anything while using custom doclet
