### PR TITLE
fix: Add native image feature to register protobuf reflection in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -837,6 +837,7 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
+                <buildArg>--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature</buildArg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
Fixes native image test failures such as in https://github.com/googleapis/java-accesscontextmanager/pull/270 where tests use reflection on protobuf classes.
