### PR TITLE
fix(java): update dependency com.google.cloud:native-image-support to v0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -776,7 +776,7 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>native-image-support</artifactId>
-          <version>0.9.0</version>
+          <version>0.10.0</version>
           <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Updates the native-image-support to latest version to accommodate grpc `1.42.x`.