### PR TITLE
fix(java): Only enable integration tests for native image testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
           <!-- Using older version; upgrade to latest once issues are resolved. See #336 -->
-          <version>0.9.5</version>
+          <version>0.9.8</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -806,6 +806,9 @@
             <configuration>
               <!-- Include all tests during native image testing. -->
               <excludes combine.self="override" />
+              <includes>
+                <include>**/IT*.java</include>
+              </includes>
             </configuration>
           </plugin>
 
@@ -814,6 +817,7 @@
             <artifactId>native-maven-plugin</artifactId>
             <!-- Using older version; upgrade to latest once issues are resolved. See #336. -->
             <version>0.9.8</version>
+            <extensions>true</extensions>
             <executions>
               <execution>
                 <id>test-native</id>
@@ -827,7 +831,6 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
-                <buildArg>--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -790,7 +790,6 @@
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
-          <!-- Using older version; upgrade to latest once issues are resolved. See #336 -->
           <version>0.9.8</version>
           <scope>test</scope>
         </dependency>
@@ -815,7 +814,6 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <!-- Using older version; upgrade to latest once issues are resolved. See #336. -->
             <version>0.9.8</version>
             <extensions>true</extensions>
             <executions>


### PR DESCRIPTION
This PR modifies shared-config to only run integration tests during native image testing.

Notes:

* This PR removes the line `--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature` which will register all proto classes for reflection (i.e. `CreateSecretRequest`, `DeleteSecretRequest`, etc.). This is typically needed in unit tests when sometimes tests will setup some mock responses using method calls like `Any.pack(...)` which invokes reflection on the proto class that is specified. However, integration tests no longer need this. It is useful to remove this because it will make the native build run a few minutes faster.

* This PR also enables `<extensions>true</extensions>` for the `native-maven-plugin`. This is a [required setting for using the plugin](https://github.com/graalvm/native-build-tools/releases/tag/0.9.6) after version 0.9.6. 

