### PR TITLE
deps: revert dependency com.google.googlejavaformat:google-java-format to v1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <plugin>
           <groupId>com.coveo</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.13</version>
+          <version>2.9</version>
           <configuration>
             <style>google</style>
             <verbose>true</verbose>
@@ -225,7 +225,7 @@
             <dependency>
               <groupId>com.google.googlejavaformat</groupId>
               <artifactId>google-java-format</artifactId>
-              <version>1.13.0</version>
+              <version>1.7</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Causes lint failures in downstream libraries.