### PR TITLE
fix(java): Enable unit tests in generated libraries for native image testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -807,6 +807,7 @@
               <excludes combine.self="override" />
               <includes>
                 <include>**/IT*.java</include>
+                <include>**/*ClientTest.java</include>
               </includes>
             </configuration>
           </plugin>
@@ -829,6 +830,7 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
+                <buildArg>--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -807,6 +807,7 @@
               <excludes combine.self="override" />
               <includes>
                 <include>**/IT*.java</include>
+                <!-- Enable unit tests in generated libraries for native image testing. -->
                 <include>**/*ClientTest.java</include>
               </includes>
             </configuration>


### PR DESCRIPTION
Currently, only integration tests are enabled for native image testing in all libraries. However,  [the native-maven-plugin fails](https://github.com/graalvm/native-build-tools/issues/188) when no tests are run in a module. This affects modules don't have integration tests. 

To increase test coverage, we decided to enable unit tests in generated libraries for native image testing.
