### PR TITLE
ci: running apt-get update in downstream.yaml

### DIFF
--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -26,5 +26,6 @@ jobs:
       with:
         java-version: ${{matrix.java}}
     - run: java -version
+    - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
     - run: .kokoro/client-library-check.sh ${{matrix.repo}}


### PR DESCRIPTION
Testing to resolve the error below:

```
Run sudo apt-get install libxml2-utils
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  libxml2-utils
0 upgraded, 1 newly installed, 0 to remove and 17 not upgraded.
Need to get 37.1 kB of archives.
After this operation, 194 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libxml2-utils amd64 2.9.10+dfsg-5ubuntu0.20.04.1
Err:1 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libxml2-utils amd64 2.9.10+dfsg-5ubuntu0.20.04.1
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2-utils_2.9.10+dfsg-5ubuntu0.20.04.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```