### PR TITLE
test: verifying test, lint, clirr, and graalvm in checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -58,6 +58,7 @@ branchProtectionRules:
     - "build (11, java-bigquery, test)"
     - "build (11, java-bigquery, lint)"
     - "build (11, java-bigquery, clirr)"
+    - "graalvm (11, java-orgpolicy)"
     - "cla/google"
 - pattern: java7
   # Can admins overwrite branch protection.

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -46,6 +46,18 @@ branchProtectionRules:
     - "dependencies (11, java-spanner)"
     - "dependencies (11, java-storage)"
     - "dependencies (11, java-pubsub)"
+    - "build (8, java-trace, test)"
+    - "build (8, java-trace, lint)"
+    - "build (8, java-trace, clirr)"
+    - "build (8, java-bigquery, test)"
+    - "build (8, java-bigquery, lint)"
+    - "build (8, java-bigquery, clirr)"
+    - "build (11, java-trace, test)"
+    - "build (11, java-trace, lint)"
+    - "build (11, java-trace, clirr)"
+    - "build (11, java-bigquery, test)"
+    - "build (11, java-bigquery, lint)"
+    - "build (11, java-bigquery, clirr)"
     - "cla/google"
 - pattern: java7
   # Can admins overwrite branch protection.

--- a/.github/workflows/downstream-dependencies.yaml
+++ b/.github/workflows/downstream-dependencies.yaml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+name: downstream
+jobs:
+  dependencies:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11]
+        repo:
+        - java-bigquery
+        - java-bigqueryconnection
+        - java-spanner
+        - java-storage
+        - java-pubsub
+    steps:
+    - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
+    - uses: actions/setup-java@v1
+      with:
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: sudo apt-get install libxml2-utils
+    - run: .kokoro/client-library-check.sh ${{matrix.repo}} dependencies

--- a/.github/workflows/downstream-dependencies.yaml
+++ b/.github/workflows/downstream-dependencies.yaml
@@ -18,12 +18,10 @@ jobs:
         - java-storage
         - java-pubsub
     steps:
-    - uses: actions/checkout@v2
-    - uses: stCarolas/setup-maven@v4
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
-        maven-version: 3.8.1
-    - uses: actions/setup-java@v1
-      with:
+        distribution: zulu
         java-version: ${{matrix.java}}
     - run: java -version
     - run: sudo apt-get update -y

--- a/.github/workflows/downstream-dependencies.yaml
+++ b/.github/workflows/downstream-dependencies.yaml
@@ -26,5 +26,6 @@ jobs:
       with:
         java-version: ${{matrix.java}}
     - run: java -version
+    - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
     - run: .kokoro/client-library-check.sh ${{matrix.repo}} dependencies

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -29,5 +29,6 @@ jobs:
       with:
         java-version: ${{matrix.java}}
     - run: java -version
+    - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
     - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -3,8 +3,40 @@ on:
     branches:
     - main
   pull_request:
+
+# Keeping this file separate as the dependencies check would use more
+# repositories than needed this downstream check for GraalVM native image and
+# other Maven plugins.
 name: downstream
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11]
+        repo:
+        # GAPIC library
+        - java-trace
+        # Handwritten library
+        - java-bigquery
+        job-type:
+        - test  # maven-surefire-plugin
+        - lint  # fmt-maven-plugin and google-java-format
+        - clirr # clirr-maven-plugin
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: sudo apt-get update -y
+    - run: sudo apt-get install libxml2-utils
+    - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}
+
+  # GraalVM job ensures the compatibility of GraaVM version above and the
+  # native-maven-plugin version.
   graalvm:
     runs-on: ubuntu-latest
     strategy:
@@ -22,37 +54,14 @@ jobs:
     - uses: ayltai/setup-graalvm@v1
       with:
         java-version: ${{matrix.java}}
+        # When a new version of native-maven-plugin fails to run in a downstream
+        # library, it's likely to be an incompatibility with GraalVM version.
+        # In that case, you need to upgrade the Docker container used in the
+        # tests in the downstream repositories. Example PR:
+        # https://github.com/googleapis/testing-infra-docker/pull/195
         graalvm-version: 22.0.0.2
         native-image: true
     - run: java -version
     - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
     - run: .kokoro/client-library-check.sh ${{matrix.repo}} graalvm
-
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [8, 11]
-        repo:
-        # GAPIC library
-        - java-trace
-        # Handwritten library
-        - java-bigquery
-        job-type:
-        - test
-        - lint
-        - clirr
-    steps:
-    - uses: actions/checkout@v2
-    - uses: stCarolas/setup-maven@v4
-      with:
-        maven-version: 3.8.1
-    - uses: actions/setup-java@v1
-      with:
-        java-version: ${{matrix.java}}
-    - run: java -version
-    - run: sudo apt-get update -y
-    - run: sudo apt-get install libxml2-utils
-    - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -12,14 +12,15 @@ jobs:
       matrix:
         java: [8, 11]
         repo:
-        # GAPIC library
-        - java-trace
+        # GAPIC library that doesn't use a real GCP project in integration tests
+        - java-orgpolicy
         # Handwritten library
         - java-bigquery
         job-type:
         - test
         - lint
         - clirr
+        - graalvm
     steps:
     - uses: actions/checkout@v2
     - uses: stCarolas/setup-maven@v4

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -57,9 +57,9 @@ jobs:
         # When a new version of native-maven-plugin fails to run in a downstream
         # library, it's likely to be an incompatibility with GraalVM version.
         # In that case, you need to upgrade the Docker container used in the
-        # tests in the downstream repositories. Example PR:
-        # https://github.com/googleapis/testing-infra-docker/pull/195
-        graalvm-version: 22.0.0.2
+        # tests in the downstream repositories (not just this field below).
+        # Example: https://github.com/googleapis/testing-infra-docker/pull/195
+        graalvm-version: 21.2.0
         native-image: true
     - run: java -version
     - run: sudo apt-get update -y

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -12,13 +12,11 @@ jobs:
       matrix:
         java: [8, 11]
         repo:
+        # GAPIC library
+        - java-trace
+        # Handwritten library
         - java-bigquery
-        - java-bigqueryconnection
-        - java-spanner
-        - java-storage
-        - java-pubsub
         job-type:
-        - dependencies
         - test
         - lint
         - clirr
@@ -31,6 +29,5 @@ jobs:
       with:
         java-version: ${{matrix.java}}
     - run: java -version
-    - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
     - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -19,9 +19,11 @@ jobs:
     - uses: stCarolas/setup-maven@v4
       with:
         maven-version: 3.8.1
-    - uses: actions/setup-java@v1
+    - uses: ayltai/setup-graalvm@v1
       with:
         java-version: ${{matrix.java}}
+        graalvm-version: 22.0.0.2
+        native-image: true
     - run: java -version
     - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -55,11 +55,11 @@ jobs:
       with:
         java-version: ${{matrix.java}}
         # When a new version of native-maven-plugin fails to run in a downstream
-        # library, it's likely to be an incompatibility with GraalVM version.
+        # library, it's likely to be an incompatibility with the GraalVM version.
         # In that case, you need to upgrade the Docker container used in the
-        # tests in the downstream repositories (not just this field below).
+        # tests in the downstream repositories (not just this value below).
         # Example: https://github.com/googleapis/testing-infra-docker/pull/195
-        graalvm-version: 21.2.0
+        graalvm-version: 22.0.0.2
         native-image: true
     - run: java -version
     - run: sudo apt-get update -y

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -5,6 +5,28 @@ on:
   pull_request:
 name: downstream
 jobs:
+  graalvm:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [11]
+        repo:
+        # GAPIC library that doesn't use a real GCP project in integration tests
+        - java-orgpolicy
+    steps:
+    - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
+    - uses: actions/setup-java@v1
+      with:
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: sudo apt-get update -y
+    - run: sudo apt-get install libxml2-utils
+    - run: .kokoro/client-library-check.sh ${{matrix.repo}} graalvm
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -12,15 +34,14 @@ jobs:
       matrix:
         java: [8, 11]
         repo:
-        # GAPIC library that doesn't use a real GCP project in integration tests
-        - java-orgpolicy
+        # GAPIC library
+        - java-trace
         # Handwritten library
         - java-bigquery
         job-type:
         - test
         - lint
         - clirr
-        - graalvm
     steps:
     - uses: actions/checkout@v2
     - uses: stCarolas/setup-maven@v4

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 name: downstream
 jobs:
-  dependencies:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/downstream.yaml
+++ b/.github/workflows/downstream.yaml
@@ -17,6 +17,11 @@ jobs:
         - java-spanner
         - java-storage
         - java-pubsub
+        job-type:
+        - dependencies
+        - test
+        - lint
+        - clirr
     steps:
     - uses: actions/checkout@v2
     - uses: stCarolas/setup-maven@v4
@@ -28,4 +33,4 @@ jobs:
     - run: java -version
     - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
-    - run: .kokoro/client-library-check.sh ${{matrix.repo}}
+    - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -21,12 +21,15 @@ set -eo pipefail
 # Display commands being run.
 set -x
 
-if [[ $# -lt 1 ]];
+if [[ $# -ne 2 ]];
 then
-  echo "Usage: $0 <repo-name>"
+  echo "Usage: $0 <repo-name> <job-type>"
+  echo "where repo-name is java-XXX and check-type is dependencies, lint, or clirr"
   exit 1
 fi
 REPO=$1
+# build.sh uses this environment variable
+export JOB_TYPE=$2
 
 ## Get the directory of the build script
 scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
@@ -61,5 +64,17 @@ set ${VERSION}
 save pom.xml
 EOF
 
-# run dependencies script
-.kokoro/dependencies.sh
+case ${JOB_TYPE} in
+dependencies)
+    .kokoro/dependencies.sh
+    RETURN_CODE=$?
+    ;;
+*)
+    # This reads the JOB_TYPE environmental variable
+    .kokoro/build.sh
+    RETURN_CODE=$?
+    ;;
+esac
+
+echo "exiting with ${RETURN_CODE}"
+exit ${RETURN_CODE}


### PR DESCRIPTION
My attempt to run "test", "lint", and "clirr" in downstream tests. These checks ensure the maven-surefire-plugin, fmt-maven-plugin, and clirr-maven-plugin work as expected in the 2 client libraries (GAPIC and hand-written).

I don't intent to catch every failure cases in every downstream libraries, but I believe this setup will catch 90% of cases where plugin upgrades don't work in downstream repositories (and we would re-release the shared config again). Example: https://github.com/googleapis/java-shared-config/issues/452

CC: @Neenu1995 

# What if upgrading fmt-maven-plugin require adjusting Java code?

This PR changes the lint as a required check. This may introduce circular dependency.

For example, upgrading google-java-format to 1.15 requires code change in the downstream repository https://github.com/googleapis/java-shared-config/issues/452#issuecomment-1080809559 
This require code change in the repository:
```
 /** Static utility methods for working with Errors returned from the service. */
 public class Errors {
-  private Errors() {};
+  private Errors() {}
+  ;
```

But we first would need to release the shared config before making the formatting change. How do we deal with it?

=> We can run  `mvn com.coveo:fmt-maven-plugin:format` in the script to format the code before running `com.coveo:fmt-maven-plugin:check`:

<img width="581" alt="Screen Shot 2022-03-28 at 4 11 07 PM" src="https://user-images.githubusercontent.com/28604/160478971-8e8ffc70-a431-4236-a1a8-30c37e8172b5.png">

