### PR TITLE
test: versioning maven-failsafe-plugin and maven-surefire-plugin together

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <report.jxr.inherited>false</report.jxr.inherited>
     <skipITs>true</skipITs>
     <auto-value-annotation.version>1.9</auto-value-annotation.version>
-    <surefire.version>3.0.0-M5</surefire.version>
+    <surefire.version>3.0.0-M6</surefire.version>
     <docRoot>/java/docs/reference/</docRoot>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <report.jxr.inherited>false</report.jxr.inherited>
     <skipITs>true</skipITs>
     <auto-value-annotation.version>1.9</auto-value-annotation.version>
+    <surefire.version>3.0.0-M5</surefire.version>
     <docRoot>/java/docs/reference/</docRoot>
   </properties>
 
@@ -85,7 +86,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>${surefire.version}</version>
           <configuration>
             <!-- Excludes integration tests and smoke tests when unit tests are run -->
             <excludes>
@@ -98,7 +99,7 @@
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>3.0.0-M5</version>
+              <version>${surefire.version}</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -129,7 +130,8 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M4</version>
+          <!-- this plugin is released along with maven-surefire-plugin -->
+          <version>${surefire.version}</version>
           <configuration>
             <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
             <reportNameSuffix>sponge_log</reportNameSuffix>
@@ -142,7 +144,7 @@
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>3.0.0-M4</version>
+              <version>${surefire.version}</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
I observe the maven-surefire-plugin and maven-failsafe-plugin are released together.

- https://maven.apache.org/surefire/maven-surefire-plugin/ (Version: 3.0.0-M5; Last Published: 2020-06-13)
- https://maven.apache.org/surefire/maven-failsafe-plugin/ (Version: 3.0.0-M5; Last Published: 2020-06-13)

Upgrading them individually leads build failures in pull requests:
https://github.com/googleapis/java-shared-config/pull/398, https://github.com/googleapis/java-shared-config/pull/399#issuecomment-1082334135
