### PR TITLE
fix(java): remove protobuf feature from native profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -831,7 +831,6 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
-                <buildArg>--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature</buildArg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
The Protobuf feature will be brought in automatically after https://github.com/googleapis/gax-java/pull/1641 is merged and released. 