### PR TITLE
chore: upgrade graalvm version to 22.2

### DIFF
--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -59,7 +59,7 @@ jobs:
         # In that case, you need to upgrade the Docker container used in the
         # tests in the downstream repositories (not just this value below).
         # Example: https://github.com/googleapis/testing-infra-docker/pull/195
-        graalvm-version: 22.0.0.2
+        graalvm-version: 22.2.0
         native-image: true
     - run: java -version
     - run: sudo apt-get update -y


### PR DESCRIPTION
Address `--allow-incomplete-classpath` issues seen in https://github.com/googleapis/java-shared-config/pull/523
