### PR TITLE
chore: group GraalVM native image deps

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -28,5 +28,6 @@ java.common_templates(
         ".github/workflows/auto-release.yaml",
         ".github/workflows/samples.yaml",
         "samples/*",
+        "renovate.json"
     ]
 )

--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,12 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^org.graalvm.buildtools"
+      ],
+      "groupName": "GraalVM native-image dependencies"
     }
   ],
   "semanticCommits": true,

--- a/renovate.json
+++ b/renovate.json
@@ -68,12 +68,6 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
-    },
-    {
-      "packagePatterns": [
-        "^org.graalvm.buildtools"
-      ],
-      "groupName": "GraalVM native-image dependencies"
     }
   ],
   "semanticCommits": true,


### PR DESCRIPTION
Grouping GraalVM native image dependencies in RenovateBot configuration file.

Currently they are treated individual, irrelevant artifacts:

<img width="780" alt="Screen Shot 2022-10-25 at 10 47 37 PM" src="https://user-images.githubusercontent.com/28604/197922648-c3f81c0d-5a40-4664-90fc-3012d4318a04.png">



