### PR TITLE
chore: remove graalvm GA check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -47,7 +47,6 @@ branchProtectionRules:
     - "build (11, java-bigquery, test)"
     - "build (11, java-bigquery, lint)"
     - "build (11, java-bigquery, clirr)"
-    - "graalvm (11, java-orgpolicy)"
     - "cla/google"
 - pattern: java7
   # Can admins overwrite branch protection.


### PR DESCRIPTION
https://github.com/googleapis/java-shared-config/pull/616 is stuck on this job despite being removed so attempting to remove it in a separate PR. 