### PR TITLE
ci: remove java-bigqueryconnection from required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -38,7 +38,6 @@ branchProtectionRules:
     - "Kokoro - Test: Java GraalVM Native Image"
     - "Kokoro - Test: Java 17 GraalVM Native Image"
     - "dependencies (11, java-bigquery)"
-    - "dependencies (11, java-bigqueryconnection)"
     - "dependencies (11, java-spanner)"
     - "dependencies (11, java-storage)"
     - "dependencies (11, java-pubsub)"


### PR DESCRIPTION
The java-bigqueryconnection repository has been migrated to the monorepo. We cannot use it as the test.