### PR TITLE
feat: ensure .repo-metadata.json file is included in published jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,22 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+          <configuration>
+            <resources>
+              <resource>
+                <directory>../</directory>
+                <includes>
+                  <include>.repo-metadata.json</include>
+                </includes>
+              </resource>
+            </resources>
+            <outputDirectory>${project.build.outputDirectory}/META-INF/</outputDirectory>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>1.6.13</version>


### PR DESCRIPTION
The .repo-metadata.json file in each repo includes useful metadata that should be included in published jars. 

To test this change locally:

1) Pull down this change and run `mvn clean install -Dskiptests` to install a local copy of `google-cloud-shared-config` to your machine
2) Clone your favorite client library repo (say `google-cloud-java`) and run `mvn clean package -DskipTests`
3) Extract the generated jar and examine the contents. The `.repo-metadata.json` file should exist under the `META-INF` directory, next to the `INDEX.LIST` and `MANIFEST.MF` files.