### PR TITLE
chore: remove dependencies (11) from list of required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -29,7 +29,6 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - "dependencies (11)"
     - "lint"
     - "clirr"
     - "units (8)"


### PR DESCRIPTION
The dependencies (11) check was removed in https://github.com/googleapis/java-shared-config/pull/655/
