### PR TITLE
Revert "build(deps): update dependency org.apache.maven.plugins:maven-javadoc-plugin to v3.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.5.0</version>
         <reportSets>
           <reportSet>
             <id>html</id>
@@ -569,7 +569,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.5.0</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -701,7 +701,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.5.0</version>
             <configuration>
               <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
               <useStandardDocletOptions>false</useStandardDocletOptions>              


### PR DESCRIPTION
Reverts googleapis/java-shared-config#656

This version update currently breaks javadoc generation with v1.9.0+ of the doclet used for Cloud RAD.