### PR TITLE
ci: mark javadoc-with-doclet as required

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -49,6 +49,7 @@ branchProtectionRules:
     - "build (11, java-bigquery, lint)"
     - "build (11, java-bigquery, clirr)"
     - "build (11, java-bigtable, javadoc)"
+    - "javadoc-with-doclet (java-bigtable)"
     - "cla/google"
 - pattern: java7
   # Can admins overwrite branch protection.


### PR DESCRIPTION
Update sync-repo-settings.yaml to mark "javadoc-with-doclet (java-bigtable)" as required

