### PR TITLE
chore: Update downstream-dependencies.yaml with java-bigquerystorage

### DIFF
--- a/.github/workflows/downstream-dependencies.yaml
+++ b/.github/workflows/downstream-dependencies.yaml
@@ -13,6 +13,7 @@ jobs:
         java: [11]
         repo:
         - java-bigquery
+        - java-bigquerystorage
         - java-spanner
         - java-storage
         - java-pubsub


### PR DESCRIPTION
Adding java-bigquerystorage to the list of repos checked for downstream dependencies check. 
It [uses](https://github.com/googleapis/java-bigquerystorage/blob/main/google-cloud-bigquerystorage/pom.xml#L86) **${auto-value}.version**