### PR TITLE
feat: add graal-sdk dependency management to java-shared-config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-shared-config</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.9-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-config:current} -->
+  <version>1.5.8</version><!-- {x-version-update:google-cloud-shared-config:current} -->
   <name>Google Cloud</name>
   <url>https://github.com/googleapis/java-shared-config</url>
   <description>
@@ -541,12 +541,7 @@
         <artifactId>auto-value-annotations</artifactId>
         <version>${auto-value.version}</version>
       </dependency>
-
-    <!--
-    java-shared-config comes first in the release train. Defining the graal-sdk
-    version here will allow us manage the dependency from a single location
-    instead of needing to define it multiple repos (e.g gax, java-spanner)
-    -->
+      
       <dependency>
         <groupId>org.graalvm.sdk</groupId>
         <artifactId>graal-sdk</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-shared-config</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.8</version><!-- {x-version-update:google-cloud-shared-config:current} -->
+  <version>1.5.9-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-config:current} -->
   <name>Google Cloud</name>
   <url>https://github.com/googleapis/java-shared-config</url>
   <description>
@@ -65,6 +65,7 @@
     <skipITs>true</skipITs>
     <auto-value.version>1.10.4</auto-value.version>
     <surefire.version>3.1.2</surefire.version>
+    <graal-sdk.version>22.3.2</graal-sdk.version>
     <docRoot>/java/docs/reference/</docRoot>
   </properties>
 
@@ -539,6 +540,17 @@
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value-annotations</artifactId>
         <version>${auto-value.version}</version>
+      </dependency>
+
+    <!--
+    java-shared-config comes first in the release train. Defining the graal-sdk
+    version here will allow us manage the dependency from a single location
+    instead of needing to define it multiple repos (e.g gax, java-spanner)
+    -->
+      <dependency>
+        <groupId>org.graalvm.sdk</groupId>
+        <artifactId>graal-sdk</artifactId>
+        <version>${graal-sdk.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Tested locally by removing graal-sdk version declaration from gax:

```
 <dependency>
        <groupId>org.graalvm.sdk</groupId>
        <artifactId>graal-sdk</artifactId>
        <version>${graal-sdk.version}</version>
      </dependency>
```
And calling `mvn dependency:tree`:

<img width="795" alt="Screenshot 2023-10-11 at 4 32 55 PM" src="https://github.com/googleapis/java-shared-config/assets/66699525/7d1854e7-9d81-419c-a787-8fa6a8fdcccb">


