### PR TITLE
chore: add java-shared-config to safe.directory and mark docker validation check as required

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -36,6 +36,7 @@ branchProtectionRules:
     - "Kokoro - Test: Integration"
     - "Kokoro - Test: Java GraalVM Native Image"
     - "Kokoro - Test: Java 17 GraalVM Native Image"
+    - "Kokoro - Test: Docker Image Validation"
     - "dependencies (11, java-bigquery)"
     - "dependencies (11, java-spanner)"
     - "dependencies (11, java-storage)"

--- a/.kokoro/verify-docker-images.sh
+++ b/.kokoro/verify-docker-images.sh
@@ -7,8 +7,6 @@ function fetch_image_names() {
   export imageNames
   echo "$imageNames"
 }
-echo "Check if git is installed:"
-which git
 
 git config --global --add safe.directory /tmpfs/src/github/java-shared-config
 
@@ -22,10 +20,6 @@ javaSharedConfigVersion="$(mvn help:evaluate -Dexpression=project.version -q -Df
 
 branchName=$(git name-rev "${KOKORO_GIT_COMMIT}" | sed 's/.* //')
 gitCommitMessage=$(git log -1 "$(git rev-parse --short "${KOKORO_GIT_COMMIT}")" | grep "chore(main): release *")
-
-echo "${KOKORO_GIT_COMMIT}"
-echo "${branchName}"
-echo "${gitCommitMessage}"
 
 # GraalVM docker images are not tagged with SNAPSHOT versions.
 if [[ "${branchName}" == *"release-please--branches--main"* ]] && [[ ! $gitCommitMessage =~ "SNAPSHOT" ]]; then

--- a/.kokoro/verify-docker-images.sh
+++ b/.kokoro/verify-docker-images.sh
@@ -10,6 +10,8 @@ function fetch_image_names() {
 echo "Check if git is installed:"
 which git
 
+git config --global --add safe.directory /tmpfs/src/github/java-shared-config
+
 # Get the directory of the build script
 scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 # cd to the parent directory, i.e. the root of the git repo
@@ -18,8 +20,8 @@ cd ${scriptDir}/.. || exit
 # Fetch the java-shared-config version in source of the current commit.
 javaSharedConfigVersion="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 
-branchName=$(git name-rev "$KOKORO_GIT_COMMIT" | sed 's/.* //')
-gitCommitMessage=$(git log -1 "$(git rev-parse --short "$KOKORO_GIT_COMMIT")" | grep "chore(main): release *")
+branchName=$(git name-rev "${KOKORO_GIT_COMMIT}" -v | sed 's/.* //')
+gitCommitMessage=$(git log -1 "$(git rev-parse --short "${KOKORO_GIT_COMMIT}")" | grep "chore(main): release *")
 
 echo "${KOKORO_GIT_COMMIT}"
 echo "${branchName}"

--- a/.kokoro/verify-docker-images.sh
+++ b/.kokoro/verify-docker-images.sh
@@ -20,7 +20,7 @@ cd ${scriptDir}/.. || exit
 # Fetch the java-shared-config version in source of the current commit.
 javaSharedConfigVersion="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 
-branchName=$(git name-rev "${KOKORO_GIT_COMMIT}" -v | sed 's/.* //')
+branchName=$(git name-rev "${KOKORO_GIT_COMMIT}" | sed 's/.* //')
 gitCommitMessage=$(git log -1 "$(git rev-parse --short "${KOKORO_GIT_COMMIT}")" | grep "chore(main): release *")
 
 echo "${KOKORO_GIT_COMMIT}"

--- a/.kokoro/verify-docker-images.sh
+++ b/.kokoro/verify-docker-images.sh
@@ -7,6 +7,8 @@ function fetch_image_names() {
   export imageNames
   echo "$imageNames"
 }
+echo "Check if git is installed:"
+which git
 
 # Get the directory of the build script
 scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
@@ -18,6 +20,10 @@ javaSharedConfigVersion="$(mvn help:evaluate -Dexpression=project.version -q -Df
 
 branchName=$(git name-rev "$KOKORO_GIT_COMMIT" | sed 's/.* //')
 gitCommitMessage=$(git log -1 "$(git rev-parse --short "$KOKORO_GIT_COMMIT")" | grep "chore(main): release *")
+
+echo "${KOKORO_GIT_COMMIT}"
+echo "${branchName}"
+echo "${gitCommitMessage}"
 
 # GraalVM docker images are not tagged with SNAPSHOT versions.
 if [[ "${branchName}" == *"release-please--branches--main"* ]] && [[ ! $gitCommitMessage =~ "SNAPSHOT" ]]; then


### PR DESCRIPTION
The `Kokoro - Test:Docker Image Validation` is returning empty results for `branchName` and `gitCommitMessage` in https://github.com/googleapis/java-shared-config/pull/687. This is leading to the check passing for the incorrect reason (i.e the check passes even though `gcr.io/cloud-devrel-public-resources/graalvma:1.6.0` has not been published.) Root cause from logs:
```
Executing: docker run --rm --interactive --network=host --privileged --volume=/var/run/docker.sock:/var/run/docker.sock --workdir=/tmpfs/src --entrypoint=github/java-shared-config/.kokoro/verify-docker-images.sh --env-file=/tmpfs/tmp/tmp80fng0kc/envfile --volume=/tmpfs:/tmpfs gcr.io/cloud-devrel-kokoro-resources/java8
fatal: detected dubious ownership in repository at '/tmpfs/src/github/java-shared-config'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmpfs/src/github/java-shared-config
fatal: detected dubious ownership in repository at '/tmpfs/src/github/java-shared-config'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmpfs/src/github/java-shared-config
fatal: detected dubious ownership in repository at '/tmpfs/src/github/java-shared-config'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmpfs/src/github/java-shared-config
```  
