### PR TITLE
deps: update graal-sdk to 22.3.3

### DIFF
--- a/.cloudbuild/cloudbuild-test.yaml
+++ b/.cloudbuild/cloudbuild-test.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _JAVA_SHARED_CONFIG_VERSION: '1.6.0'
+  _JAVA_SHARED_CONFIG_VERSION: '1.6.1'
   _GRAALVM_A: 'graalvm22_3_jdk11'
   _GRAALVM_B: 'graalvm22_3_jdk17'
 steps:

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _JAVA_SHARED_CONFIG_VERSION: '1.6.0'
+  _JAVA_SHARED_CONFIG_VERSION: '1.6.1'
   _GRAALVM_A: 'graalvm22_3_jdk11'
   _GRAALVM_B: 'graalvm22_3_jdk17'
 steps:

--- a/.cloudbuild/graalvm22_3_jdk11.Dockerfile
+++ b/.cloudbuild/graalvm22_3_jdk11.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-22.3.2-b1
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-22.3.3-b1
 
 RUN gu install native-image && \
     yum update -y && \

--- a/.cloudbuild/graalvm22_3_jdk11.yaml
+++ b/.cloudbuild/graalvm22_3_jdk11.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"11.0.19\"", "GraalVM CE 22.3.2"]
+    expectedError: ["openjdk version \"11.0.19\"", "GraalVM CE 22.3.3"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]

--- a/.cloudbuild/graalvm22_3_jdk11.yaml
+++ b/.cloudbuild/graalvm22_3_jdk11.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"11.0.19\"", "GraalVM CE 22.3.3"]
+    expectedError: ["openjdk version \"11.0.20\"", "GraalVM CE 22.3.3"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]

--- a/.cloudbuild/graalvm22_3_jdk17.Dockerfile
+++ b/.cloudbuild/graalvm22_3_jdk17.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-22.3.2-b1
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-22.3.3-b1
 
 RUN gu install native-image && \
     yum update -y && \

--- a/.cloudbuild/graalvm22_3_jdk17.yaml
+++ b/.cloudbuild/graalvm22_3_jdk17.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"17.0.7\"", "GraalVM CE 22.3.2"]
+    expectedError: ["openjdk version \"17.0.7\"", "GraalVM CE 22.3.3"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]

--- a/.cloudbuild/graalvm22_3_jdk17.yaml
+++ b/.cloudbuild/graalvm22_3_jdk17.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"17.0.7\"", "GraalVM CE 22.3.3"]
+    expectedError: ["openjdk version \"17.0.8\"", "GraalVM CE 22.3.3"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <skipITs>true</skipITs>
     <auto-value.version>1.10.4</auto-value.version>
     <surefire.version>3.2.1</surefire.version>
-    <graal-sdk.version>22.3.2</graal-sdk.version>
+    <graal-sdk.version>22.3.3</graal-sdk.version>
     <docRoot>/java/docs/reference/</docRoot>
   </properties>
 


### PR DESCRIPTION
- Following up on https://github.com/googleapis/java-shared-config/pull/684#issuecomment-1785374314. To make the graal-sdk in sync with the graalvm container image, this PR updates the graals-sdk version to 22.3.3 for now until the container image of 22.3.4 is available. 

- This PR also updates the graalvm docker image generated by java-shared-config (not in use just yet) and the image tag in preparation for the 1.6.1 release. 
