### PR TITLE
chore: update graalvm docker image for 1.7.0 release

### DIFF
--- a/.cloudbuild/cloudbuild-test.yaml
+++ b/.cloudbuild/cloudbuild-test.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _JAVA_SHARED_CONFIG_VERSION: '1.6.1'
+  _JAVA_SHARED_CONFIG_VERSION: '1.7.0' # {x-version-update:google-cloud-shared-config:released}
   _GRAALVM_A: 'graalvm22_3_jdk11'
   _GRAALVM_B: 'graalvm22_3_jdk17'
 steps:

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _JAVA_SHARED_CONFIG_VERSION: '1.6.1'
+  _JAVA_SHARED_CONFIG_VERSION: '1.7.0' # {x-version-update:google-cloud-shared-config:released}
   _GRAALVM_A: 'graalvm22_3_jdk11'
   _GRAALVM_B: 'graalvm22_3_jdk17'
 steps:

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,5 +1,6 @@
 releaseType: java-yoshi
 handleGHRelease: true
+extraFiles: [".cloudbuild/cloudbuild.yaml", ".cloudbuild/cloudbuild-test.yaml"]
 branches:
 - bumpMinorPreMajor: true
   handleGHRelease: true


### PR DESCRIPTION
The docker image tag update was missed in https://github.com/googleapis/java-shared-config/pull/716. 
This PR also sets up release-please to update the tag automatically. 
