### PR TITLE
chore: update java-shared-config version based on current version

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 timeout: 7200s # 2 hours
 substitutions:
-  _JAVA_SHARED_CONFIG_VERSION: '1.7.1' # {x-version-update:google-cloud-shared-config:released}
+  _JAVA_SHARED_CONFIG_VERSION: '1.7.1' # {x-version-update:google-cloud-shared-config:current}
   _GRAALVM_A: 'graalvm22_3_jdk11'
   _GRAALVM_B: 'graalvm22_3_jdk17'
 steps:


### PR DESCRIPTION
Modifying release-please to update java-shared-config's version to SNAPSHOTs in `cloudbuild.yaml`. This will help mitigate the risk of a manual trigger of the Cloud Build job accidentally updating a published image. 
