### PR TITLE
fix: update docFX config

### DIFF
--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -60,11 +60,6 @@ fi
 
 pushd ${REPO}
 
-# print the original pom.xml for debugging purposes
-echo "Original pom.xml:"
-cat pom.xml
-echo "END OF original pom.xml"
-
 # replace version
 xmllint --shell <(cat pom.xml) << EOF
 setns x=http://maven.apache.org/POM/4.0.0

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -69,6 +69,11 @@ set ${VERSION}
 save pom.xml
 EOF
 
+# print the updated pom.xml for debugging purposes
+echo "Updated pom.xml:"
+cat pom.xml
+echo "END OF pom.xml"
+
 case ${JOB_TYPE} in
 dependencies)
     .kokoro/dependencies.sh

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -60,6 +60,11 @@ fi
 
 pushd ${REPO}
 
+# print the original pom.xml for debugging purposes
+echo "Original pom.xml:"
+cat pom.xml
+echo "END OF original pom.xml"
+
 # replace version
 xmllint --shell <(cat pom.xml) << EOF
 setns x=http://maven.apache.org/POM/4.0.0

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -130,11 +130,6 @@ else
   replace_java_shared_config_version "${JAVA_SHARED_CONFIG_VERSION}"
 fi
 
-# print the updated pom.xml for debugging purposes
-echo "Updated pom.xml:"
-cat pom.xml
-echo "END OF pom.xml"
-
 case ${JOB_TYPE} in
 dependencies)
     .kokoro/dependencies.sh

--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -581,7 +581,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.3</version>
+            <version>3.5.0</version>
             <configuration>
               <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
               <useStandardDocletOptions>false</useStandardDocletOptions>              

--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -572,37 +572,27 @@
       </activation>
       <properties>
         <!-- default config values -->
-        <docletName>java-docfx-doclet-1.9.0</docletName>
-        <docletPath>${env.KOKORO_GFILE_DIR}/${docletName}.jar</docletPath>
         <outputpath>${project.build.directory}/docfx-yml</outputpath>
         <projectname>${project.artifactId}</projectname>
-        <excludeclasses></excludeclasses>
-        <excludePackages></excludePackages>
-        <source>8</source>            
-        <sourceFileExclude></sourceFileExclude>
+        <source>17</source>
       </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.5.0</version>
+            <version>3.6.3</version>
             <configuration>
               <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
               <useStandardDocletOptions>false</useStandardDocletOptions>              
               <additionalOptions>
                 -outputpath ${outputpath} 
-                -projectname ${projectname} 
-                -excludeclasses ${excludeclasses}: 
-                -excludepackages ${excludePackages}:
+                -projectname ${projectname}
               </additionalOptions>
               <doclint>none</doclint>
               <show>protected</show>
               <nohelp>true</nohelp>
               <source>${source}</source>
-              <sourceFileExcludes>
-                <exclude>${sourceFileExclude}</exclude>
-              </sourceFileExcludes>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
This should fix https://github.com/googleapis/java-shared-config/issues/680

The issue is that starting with maven-javadoc-plugin v3.6.0, passing in null parameters into <sourceFileExcludes> caused javadoc generation to fail. This PR removes that parameter and also updates the javadoc source to use Java 17 source as that is what we're publishing javadocs with now. 