### PR TITLE
chore: use sdk-platform-java-config in downstream checks for spanner and pubsub; update junit-vintage to 5.10.2

### DIFF
--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -106,7 +106,7 @@ SDK_PLATFORM_JAVA_CONFIG_VERSION=$(get_current_version_from_versions_txt version
 RELEASED_SHARED_DEPENDENCIES_VERSION=$(get_released_version_from_versions_txt versions.txt "google-cloud-shared-dependencies")
 pushd sdk-platform-java-config
 
-# Only update java-shared-config but keep java-shared-dependencies at the release version
+# Use released version of google-cloud-shared-dependencies to avoid verifying SNAPSHOT changes.
 replace_java_shared_config_version "${JAVA_SHARED_CONFIG_VERSION}"
 replace_java_shared_dependencies_version "${RELEASED_SHARED_DEPENDENCIES_VERSION}"
 mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
@@ -122,7 +122,8 @@ fi
 
 pushd ${REPO}
 
-# Replace sdk-plaform-java-config version in java-spanner and java-pubsub.
+# TODO(#748): Replace the version of sdk-platform-java-config for all libraries. This logic will no longer
+#  be needed after the rest of the handwritten libraries are migrated to use this artifact.
 if [ "$REPO" == "java-spanner" ] || [ "$REPO" == "java-pubsub" ]; then
   replace_sdk_platform_java_config_version "${SDK_PLATFORM_JAVA_CONFIG_VERSION}"
 else

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -36,33 +36,36 @@ function get_released_version_from_versions_txt() {
 }
 
 function replace_java_shared_config_version() {
+  version=$1
   # replace version
   xmllint --shell <(cat pom.xml) << EOF
   setns x=http://maven.apache.org/POM/4.0.0
   cd .//x:artifactId[text()="google-cloud-shared-config"]
   cd ../x:version
-  set ${JAVA_SHARED_CONFIG_VERSION}
+  set ${version}
   save pom.xml
 EOF
 }
 
-function use_released_java_shared_dependencies_version() {
+function replace_java_shared_dependencies_version() {
+  version=$1
   # replace version
   xmllint --shell <(cat pom.xml) << EOF
   setns x=http://maven.apache.org/POM/4.0.0
   cd .//x:properties/x:google-cloud-shared-dependencies.version
-  set ${RELEASED_SHARED_DEPENDENCIES_VERSION}
+  set ${version}
   save pom.xml
 EOF
 }
 
 function replace_sdk_platform_java_config_version() {
+  version=$1
   # replace version
   xmllint --shell <(cat pom.xml) << EOF
   setns x=http://maven.apache.org/POM/4.0.0
   cd .//x:artifactId[text()="sdk-platform-java-config"]
   cd ../x:version
-  set ${SDK_PLATFORM_JAVA_CONFIG_VERSION}
+  set ${version}
   save pom.xml
 EOF
 }
@@ -104,8 +107,8 @@ RELEASED_SHARED_DEPENDENCIES_VERSION=$(get_released_version_from_versions_txt ve
 pushd sdk-platform-java-config
 
 # Only update java-shared-config but keep java-shared-dependencies at the release version
-replace_java_shared_config_version
-use_released_java_shared_dependencies_version
+replace_java_shared_config_version "${JAVA_SHARED_CONFIG_VERSION}"
+replace_java_shared_dependencies_version "${RELEASED_SHARED_DEPENDENCIES_VERSION}"
 mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
 popd
 
@@ -121,9 +124,9 @@ pushd ${REPO}
 
 # Replace sdk-plaform-java-config version in java-spanner and java-pubsub.
 if [ "$REPO" == "java-spanner" ] || [ "$REPO" == "java-pubsub" ]; then
-  replace_sdk_platform_java_config_version
+  replace_sdk_platform_java_config_version "${SDK_PLATFORM_JAVA_CONFIG_VERSION}"
 else
-  replace_java_shared_config_version
+  replace_java_shared_config_version "${JAVA_SHARED_CONFIG_VERSION}"
 fi
 
 case ${JOB_TYPE} in

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -24,7 +24,7 @@ set -x
 function get_version_from_versions_txt() {
   versions=$1
   key=$2
-  version=$(grep "$key:" "${versions}" | cut -d: -f1) # 1st field is current
+  version=$(grep "$key:" "${versions}" | cut -d: -f3) # 3rd field is current
   echo "${version}"
 }
 
@@ -97,7 +97,7 @@ fi
 
 pushd ${REPO}
 
-# Replace sdk-plaform-java-config version in java-spanner and java-pubsub. 
+# Replace sdk-plaform-java-config version in java-spanner and java-pubsub.
 if [ "$REPO" == "java-spanner" ] || [ "$REPO" == "java-pubsub" ]; then
   replace_sdk_platform_java_config_version
 else

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -85,6 +85,7 @@ pushd sdk-platform-java
 SDK_PLATFORM_JAVA_CONFIG_VERSION=$(get_version_from_versions_txt versions.txt "google-cloud-shared-dependencies")
 pushd sdk-platform-java-config
 replace_java_shared_config_version
+mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
 popd
 
 # Check this BOM against a few java client libraries

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
-          <version>5.9.3</version>
+          <version>5.10.2</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -185,7 +185,7 @@
               <dependency>
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
-                <version>5.9.3</version>
+                <version>5.10.2</version>
               </dependency>
             </dependencies>
             <configuration>


### PR DESCRIPTION
**For java-spanner, java-pubsub dependencies dw check**:
- Use sdk-platform-java-config. 
- Since we are verifying changes in java-shared-config, explicitly set shared-dependencies in sdk-platform-java-config to currently released version to ensure that we're not testing any SNAPSHOT changes from sdk-platform-java.


**Additional fix to address Graalvm downstream check failure**:

The downstream GraalVM checks have been failing with:
```
Exception in thread "main" java.lang.NoSuchMethodError: org.junit.platform.engine.TestDescriptor.getAncestors()
Step #2: 	at org.junit.platform.launcher.core.StackTracePruningEngineExecutionListener.getTestClassNames(StackTracePruningEngineExecutionListener.java:50)
Step #2: 	at org.junit.platform.launcher.core.StackTracePruningEngineExecutionListener.executionFinished(StackTracePruningEngineExecutionListener.java:39)
Step #2: 	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:46)
Step #2: 	at org.junit.platform.launcher.core.OutcomeDelayingEngineExecutionListener.reportEngineFailure(OutcomeDelayingEngineExecutionListener.java:83)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:203)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
Step #2: 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
Step #2: 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:94)
Step #2: 	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
Step #2: 	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:70)
Step #2: 	at org.graalvm.junit.platform.NativeImageJUnitLauncher.execute(NativeImageJUnitLauncher.java:74)
Step #2: 	at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:129)
```

This error occurs starting with native-maven-plugin:0.9.24 which introduced some changes to be compatible with junit:5.10.0 (https://github.com/graalvm/native-build-tools/issues/472).

This PR updates the junit-vintage-engine to the latest version.
