### PR TITLE
deps: update junit-vintage-engine to 5.10.2 in native profile

### DIFF
--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
-          <version>5.9.3</version>
+          <version>5.10.2</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -185,7 +185,7 @@
               <dependency>
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
-                <version>5.9.3</version>
+                <version>5.10.2</version>
               </dependency>
             </dependencies>
             <configuration>


### PR DESCRIPTION
The downstream GraalVM checks have been failing with:
```
Exception in thread "main" java.lang.NoSuchMethodError: org.junit.platform.engine.TestDescriptor.getAncestors()
Step #2: 	at org.junit.platform.launcher.core.StackTracePruningEngineExecutionListener.getTestClassNames(StackTracePruningEngineExecutionListener.java:50)
Step #2: 	at org.junit.platform.launcher.core.StackTracePruningEngineExecutionListener.executionFinished(StackTracePruningEngineExecutionListener.java:39)
Step #2: 	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:46)
Step #2: 	at org.junit.platform.launcher.core.OutcomeDelayingEngineExecutionListener.reportEngineFailure(OutcomeDelayingEngineExecutionListener.java:83)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:203)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
Step #2: 	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
Step #2: 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
Step #2: 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:94)
Step #2: 	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
Step #2: 	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:70)
Step #2: 	at org.graalvm.junit.platform.NativeImageJUnitLauncher.execute(NativeImageJUnitLauncher.java:74)
Step #2: 	at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:129)
```

This error occurs starting with native-maven-plugin:0.9.24 which introduced some changes to be compatible with junit:5.10.0 (https://github.com/graalvm/native-build-tools/issues/472).

This PR updates the junit-vintage-engine to the latest version.