### PR TITLE
chore: remove Kokoro - Docker Image Validation check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -34,7 +34,6 @@ branchProtectionRules:
     - "units (8)"
     - "units (11)"
     - "Kokoro - Test: Integration"
-    - "Kokoro - Test: Docker Image Validation"
     - "dependencies (11, java-bigquery)"
     - "dependencies (11, java-spanner)"
     - "dependencies (11, java-storage)"


### PR DESCRIPTION
This check is now running in the stage job and is no longer needed in Github.
