### PR TITLE
chore: ignore flatten-maven-plugin updates temporarily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     ":autodetectPinVersions"
   ],
   "ignorePaths": [".kokoro/requirements.txt"],
-  "ignoreDeps": ["flatten-maven-plugin"],
+  "ignoreDeps": ["org.codehaus.mojo:flatten-maven-plugin"],
   "packageRules": [
     {
       "packagePatterns": [

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     ":autodetectPinVersions"
   ],
   "ignorePaths": [".kokoro/requirements.txt"],
+  "ignoreDeps": ["flatten-maven-plugin"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION

Temp ignore dependency update

flatten-maven-plugin v1.6.0 is causing downstream checks failures for java-spanner and java-spanner-jdbc in sdk-platform-java (reverted in https://github.com/googleapis/java-shared-config/pull/767)