### PR TITLE
Revert "build(deps): update dependency org.codehaus.mojo:flatten-maven-plugin to v1.6.0"

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -186,7 +186,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.6.0</version>
+          <version>1.3.0</version>
           <executions>
             <!-- enable flattening -->
             <execution>


### PR DESCRIPTION
Reverts googleapis/java-shared-config#772

BEGIN_COMMIT_OVERRIDE
fix: revert update dependency `org.codehaus.mojo:flatten-maven-plugin` to `v1.6.0`
END_COMMIT_OVERRIDE

This is for the observed error in https://github.com/googleapis/sdk-platform-java/pull/2571#issuecomment-1997618589