### PR TITLE
test: add all handwritten repos to downstream check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,18 @@ jobs:
         java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
+  javadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: javadoc
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,18 +85,6 @@ jobs:
         java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
-  javadoc:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: 17
-    - run: java -version
-    - run: .kokoro/build.sh
-      env:
-        JOB_TYPE: javadoc
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/downstream-dependencies.yaml
+++ b/.github/workflows/downstream-dependencies.yaml
@@ -3,7 +3,7 @@ on:
     branches:
     - main
   pull_request:
-name: downstream
+name: downstream-dependencies
 jobs:
   dependencies:
     runs-on: ubuntu-latest
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{matrix.java}}
     - run: java -version
     - run: sudo apt-get update -y
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: 11
     - run: java -version
     - run: sudo apt-get update -y

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -46,6 +46,25 @@ jobs:
     # Building using Java 17 and run the tests with Java 8 runtime
     name: "Unit test maven-plugins downstream with Java8"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+        - java-bigquery
+        - java-bigtable
+        - java-storage
+        - java-storage-nio
+        - java-spanner
+        - java-spanner-jdbc
+        - java-pubsub
+        - java-pubsublite
+        - java-logging
+        - java-logging-logback
+        - java-firestore
+        - java-datastore
+        - java-bigquerystorage
+        job-type:
+        - test  # maven-surefire-plugin
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
@@ -63,7 +82,7 @@ jobs:
         distribution: temurin
     - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
-    - run: .kokoro/client-library-check.sh ${{matrix.repo}} test # maven-surefire-plugin
+    - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}
   javadoc-with-doclet:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -33,7 +33,6 @@ jobs:
         - test  # maven-surefire-plugin
         - lint  # fmt-maven-plugin and google-java-format
         - clirr # clirr-maven-plugin
-        - javadoc # maven-javadoc-plugin
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - uses: actions/setup-java@v4

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -33,6 +33,7 @@ jobs:
         - test  # maven-surefire-plugin
         - lint  # fmt-maven-plugin and google-java-format
         - clirr # clirr-maven-plugin
+        - javadoc # maven-javadoc-plugin
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - uses: actions/setup-java@v4
@@ -64,7 +65,6 @@ jobs:
         - java-datastore
         - java-bigquerystorage
         job-type:
-        - javadoc # maven-javadoc-plugin
         - javadoc-with-doclet # test c.g.c. - specific documentation generation
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -75,9 +75,4 @@ jobs:
     - run: java -version
     - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
-    - run: |  # Conditional logic based on job-type
-        if [[ ${{matrix.job-type}} == 'javadoc' ]] ; then
-          .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}
-        elif [[ ${{matrix.job-type}} == 'javadoc-with-doclet' ]] ; then
-          .kokoro/client-library-check-doclet.sh ${{matrix.repo}}
-        fi
+    - run: .kokoro/client-library-check-doclet.sh ${{matrix.repo}}

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -14,16 +14,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17, 21]
         repo:
         - java-bigquery
         - java-bigtable
+        - java-storage
+        - java-storage-nio
+        - java-spanner
+        - java-spanner-jdbc
+        - java-pubsub
+        - java-pubsublite
+        - java-logging
+        - java-logging-logback
+        - java-firestore
+        - java-datastore
+        - java-bigquerystorage
         job-type:
         - test  # maven-surefire-plugin
         - lint  # fmt-maven-plugin and google-java-format
         - clirr # clirr-maven-plugin
-        - javadoc # maven-javadoc-plugin
-        - javadoc-with-doclet # test javadoc generation with doclet
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - uses: actions/setup-java@v4
@@ -39,6 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java: [17] # Run only on Java 17 as that's what c.g.c. generation uses
         repo:
         - java-bigtable
         - java-bigquery
@@ -53,13 +63,21 @@ jobs:
         - java-firestore
         - java-datastore
         - java-bigquerystorage
+        job-type:
+        - javadoc # maven-javadoc-plugin
+        - javadoc-with-doclet # test c.g.c. - specific documentation generation
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 17
+        java-version: ${{matrix.java}}
     - run: java -version
     - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
-    - run: .kokoro/client-library-check-doclet.sh ${{matrix.repo}}
+    - run: |  # Conditional logic based on job-type
+        if [[ ${{matrix.job-type}} == 'javadoc' ]] ; then
+          .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}
+        elif [[ ${{matrix.job-type}} == 'javadoc-with-doclet' ]] ; then
+          .kokoro/client-library-check-doclet.sh ${{matrix.repo}}
+        fi

--- a/.github/workflows/downstream-maven-plugins.yaml
+++ b/.github/workflows/downstream-maven-plugins.yaml
@@ -7,14 +7,14 @@ on:
 # Keeping this file separate as the dependencies check would use more
 # repositories than needed this downstream check for GraalVM native image and
 # other Maven plugins.
-name: downstream
+name: downstream-maven-plugins-check
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17, 21]
+        java: [17]
         repo:
         - java-bigquery
         - java-bigtable
@@ -30,19 +30,40 @@ jobs:
         - java-datastore
         - java-bigquerystorage
         job-type:
-        - test  # maven-surefire-plugin
         - lint  # fmt-maven-plugin and google-java-format
         - clirr # clirr-maven-plugin
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - uses: actions/setup-java@v4
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{matrix.java}}
     - run: java -version
     - run: sudo apt-get update -y
     - run: sudo apt-get install libxml2-utils
     - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}
+  downstream-java8:
+    # Building using Java 17 and run the tests with Java 8 runtime
+    name: "Unit test maven-plugins downstream with Java8"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: 8
+        distribution: temurin
+    - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
+      # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
+      # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+      shell: bash
+    - uses: actions/setup-java@v3
+      with:
+        java-version: 17
+        distribution: temurin
+    - run: sudo apt-get update -y
+    - run: sudo apt-get install libxml2-utils
+    - run: .kokoro/client-library-check.sh ${{matrix.repo}} test # maven-surefire-plugin
   javadoc-with-doclet:
     runs-on: ubuntu-latest
     strategy:

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -56,6 +56,7 @@ lint)
     RETURN_CODE=$?
     ;;
 javadoc)
+    echo "Running javadoc generation test"
     mvn javadoc:javadoc javadoc:test-javadoc -B -ntp -Ddoclint=none
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -56,7 +56,7 @@ lint)
     RETURN_CODE=$?
     ;;
 javadoc)
-    mvn javadoc:javadoc javadoc:test-javadoc -B -ntp
+    mvn javadoc:javadoc javadoc:test-javadoc -B -ntp -Ddoclint=none
     RETURN_CODE=$?
     ;;
 integration)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -55,6 +55,10 @@ lint)
     mvn com.coveo:fmt-maven-plugin:check -B -ntp
     RETURN_CODE=$?
     ;;
+javadoc)
+    mvn javadoc:javadoc javadoc:test-javadoc -B -ntp
+    RETURN_CODE=$?
+    ;;
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -55,10 +55,6 @@ lint)
     mvn com.coveo:fmt-maven-plugin:check -B -ntp
     RETURN_CODE=$?
     ;;
-javadoc)
-    mvn javadoc:javadoc javadoc:test-javadoc -B -ntp
-    RETURN_CODE=$?
-    ;;
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -55,11 +55,6 @@ lint)
     mvn com.coveo:fmt-maven-plugin:check -B -ntp
     RETURN_CODE=$?
     ;;
-javadoc)
-    echo "Running javadoc generation test"
-    mvn javadoc:javadoc javadoc:test-javadoc -B -ntp -Ddoclint=none
-    RETURN_CODE=$?
-    ;;
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \

--- a/owlbot.py
+++ b/owlbot.py
@@ -28,12 +28,14 @@ java.common_templates(
         ".github/release-please.yml",
         ".github/workflows/auto-release.yaml",
         ".github/workflows/samples.yaml",
+        ".github/workflows/ci.yaml",
         "samples/*",
         "renovate.json",
         ".kokoro/presubmit/graalvm-native.cfg",
         ".kokoro/presubmit/graalvm-native-17.cfg",
         ".kokoro/presubmit/common.cfg",
         ".kokoro/requirements.txt",
-        ".kokoro/requirements.in"
+        ".kokoro/requirements.in",
+        ".kokoro/build.sh"
     ]
 )


### PR DESCRIPTION
Fixes googleapis/google-cloud-java#13745  ☕️

This adds all handwritten library repos to the downstream checks for clirr, lint, and test.

This removes the `javadoc` check in favor of just checking the javadoc generation with the doclet tool as that is the main documentation generation we care about.
