### PR TITLE
chore: pin autovalue temporarily and delete guava rule.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,13 +21,6 @@
     },
     {
       "packagePatterns": [
-        "^com.google.guava:"
-      ],
-      "versionScheme": "docker",
-      "enabled": false
-    },
-    {
-      "packagePatterns": [
         "*"
       ],
       "semanticCommitType": "deps",

--- a/renovate.json
+++ b/renovate.json
@@ -17,14 +17,14 @@
       "packagePatterns": [
         "^com.google.auto.value:"
       ],
-      "rangeStrategy": "pin"
+      "enabled": false
     },
     {
       "packagePatterns": [
         "^com.google.guava:"
       ],
       "versionScheme": "docker",
-      "rangeStrategy": "pin"
+      "enabled": false
     },
     {
       "packagePatterns": [

--- a/renovate.json
+++ b/renovate.json
@@ -15,9 +15,16 @@
   "packageRules": [
     {
       "packagePatterns": [
+        "^com.google.auto.value:"
+      ],
+      "rangeStrategy": "pin"
+    },
+    {
+      "packagePatterns": [
         "^com.google.guava:"
       ],
-      "versionScheme": "docker"
+      "versionScheme": "docker",
+      "rangeStrategy": "pin"
     },
     {
       "packagePatterns": [


### PR DESCRIPTION
disable renovate bot from updating autovalue temporarily.
current autovalue version is 1.10.4 ([here](https://github.com/googleapis/java-shared-config/blob/34164052444ed9bd40a0789ed020b45cf4da17fb/java-shared-config/pom.xml#L29))

This is for lts 7, and I will manually remove this disable later.

remove renovate config for guava as there is no guava version setup in this repo, instead, it is updated in sdk-platform-java [here](https://github.com/googleapis/sdk-platform-java/blob/56775a61a054fb67a15023481cd3d0a0cf2b0496/gapic-generator-java-pom-parent/pom.xml#L33).