### PR TITLE
fix: graalvm image terraform install

### DIFF
--- a/.cloudbuild/graalvm-a.Dockerfile
+++ b/.cloudbuild/graalvm-a.Dockerfile
@@ -37,6 +37,9 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN yum install -y docker-engine docker-cli
 
 # Install terraform
+# See also https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli
+RUN yum -y install yum-utils
+RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
 RUN yum -y install terraform
 
 # Install jq

--- a/.cloudbuild/graalvm-a.Dockerfile
+++ b/.cloudbuild/graalvm-a.Dockerfile
@@ -37,9 +37,8 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN yum install -y docker-engine docker-cli
 
 # Install terraform
-# See also https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli
-RUN yum -y install yum-utils
-RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+# See also https://www.hashicorp.com/official-packaging-guide
+COPY hashicorp.repo /etc/yum.repos.d/hashicorp.repo
 RUN yum -y install terraform
 
 # Install jq

--- a/.cloudbuild/graalvm-b.Dockerfile
+++ b/.cloudbuild/graalvm-b.Dockerfile
@@ -37,6 +37,9 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN yum install -y docker-engine docker-cli
 
 # Install terraform
+# See also https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli
+RUN yum -y install yum-utils
+RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
 RUN yum -y install terraform
 
 # Install jq

--- a/.cloudbuild/graalvm-b.Dockerfile
+++ b/.cloudbuild/graalvm-b.Dockerfile
@@ -37,9 +37,8 @@ ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 RUN yum install -y docker-engine docker-cli
 
 # Install terraform
-# See also https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli
-RUN yum -y install yum-utils
-RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+# See also https://www.hashicorp.com/official-packaging-guide
+COPY hashicorp.repo /etc/yum.repos.d/hashicorp.repo
 RUN yum -y install terraform
 
 # Install jq

--- a/.cloudbuild/hashicorp.repo
+++ b/.cloudbuild/hashicorp.repo
@@ -1,0 +1,13 @@
+[hashicorp]
+name=Hashicorp Stable - $basearch
+baseurl=https://rpm.releases.hashicorp.com/RHEL/7/$basearch/stable
+enabled=1
+gpgcheck=1
+gpgkey=https://rpm.releases.hashicorp.com/gpg
+
+[hashicorp-test]
+name=Hashicorp Test - $basearch
+baseurl=https://rpm.releases.hashicorp.com/RHEL/7/$basearch/test
+enabled=0
+gpgcheck=1
+gpgkey=https://rpm.releases.hashicorp.com/gpg


### PR DESCRIPTION
Terraform install stopped working from default yum repo.

From https://www.hashicorp.com/official-packaging-guide :

> Add the HashiCorp repo
> Note: The provided repository configuration covers the supported distributions listed above. If you are using a variant not listed, you are encouraged to modify the repository configuration to suit your needs. **For example, users of RHEL 7Server or RHEL 8.3 can change the baseurl to use 7 or 8 respectively in place of the $releasever variable**.