### PR TITLE
feat: update graal-sdk to 24 and graalvm-A to 21.x

### DIFF
--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -23,12 +23,15 @@ steps:
     dir: .cloudbuild
     id: graalvm-a-build
     waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "gcr.io/cloud-devrel-public-resources/graalvm_a:${_JAVA_SHARED_CONFIG_VERSION}", "--config", ".cloudbuild/graalvm-a.yaml", "-v"]
-    waitFor: ["graalvm-a-build"]
+#  - name: gcr.io/gcp-runtimes/structure_test
+#    args:
+#      ["-i", "gcr.io/cloud-devrel-public-resources/graalvm_a:${_JAVA_SHARED_CONFIG_VERSION}", "--config", ".cloudbuild/graalvm-a.yaml", "-v"]
+#    waitFor: ["graalvm-a-build"]
   - name: gcr.io/cloud-devrel-public-resources/graalvm_a:${_JAVA_SHARED_CONFIG_VERSION}
     entrypoint: bash
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-a-build" ]
+    env:
+      - 'MODULES_UNDER_TEST=java-kms'
+      - 'GOOGLE_CLOUD_PROJECT=mpeddada-test'
 

--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -23,15 +23,12 @@ steps:
     dir: .cloudbuild
     id: graalvm-a-build
     waitFor: ["-"]
-#  - name: gcr.io/gcp-runtimes/structure_test
-#    args:
-#      ["-i", "gcr.io/cloud-devrel-public-resources/graalvm_a:${_JAVA_SHARED_CONFIG_VERSION}", "--config", ".cloudbuild/graalvm-a.yaml", "-v"]
-#    waitFor: ["graalvm-a-build"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "gcr.io/cloud-devrel-public-resources/graalvm_a:${_JAVA_SHARED_CONFIG_VERSION}", "--config", ".cloudbuild/graalvm-a.yaml", "-v"]
+    waitFor: ["graalvm-a-build"]
   - name: gcr.io/cloud-devrel-public-resources/graalvm_a:${_JAVA_SHARED_CONFIG_VERSION}
     entrypoint: bash
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-a-build" ]
-    env:
-      - 'MODULES_UNDER_TEST=java-kms'
-      - 'GOOGLE_CLOUD_PROJECT=mpeddada-test'
 

--- a/.cloudbuild/graalvm-a.Dockerfile
+++ b/.cloudbuild/graalvm-a.Dockerfile
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-22.3.3-b1
+FROM ghcr.io/graalvm/graalvm-community:21.0.2-ol7-20240116
 
-RUN gu install native-image && \
-    yum update -y && \
+RUN yum update -y && \
     yum install -y wget unzip git && \
     # Install maven
     wget -q https://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.zip -O /tmp/maven.zip && \

--- a/.cloudbuild/graalvm-a.yaml
+++ b/.cloudbuild/graalvm-a.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"21.0.2\"", "GraalVM CE 21.0.2+13.1"]
+    expectedError: ["openjdk version \"21.0.2\"", "GraalVM CE 21.0.2"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]

--- a/.cloudbuild/graalvm-a.yaml
+++ b/.cloudbuild/graalvm-a.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"11.0.20\"", "GraalVM CE 22.3.3"]
+    expectedError: ["openjdk version \"21.0.2\"", "GraalVM CE 21.0.2+13.1"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -61,9 +61,8 @@ tar -xf showcase-*
 ./gapic-showcase run &
 popd
 
-# Run showcase tests with `native` profile. Skipping ITHttpAnnotation until https://github.com/googleapis/sdk-platform-java/issues/2695 is fixed.
 pushd sdk-platform-java/showcase
-mvn test -Dtest='!com.google.showcase.v1beta1.it.ITHttpAnnotation' -Dsurefire.failIfNoSpecifiedTests=false -Pnative,-showcase -Denforcer.skip=true -ntp -B
+mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
 popd
 
 exit $RETURN_CODE

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -31,6 +31,19 @@ EOF
   popd || exit 1
 }
 
+# Find all pom.xml files that declare a specific version for the given artifact ($1)
+function find_all_poms_with_versioned_dependency {
+  poms=($(find . -name pom.xml))
+  for pom in "${poms[@]}"; do
+    if xmllint --xpath "//*[local-name()='artifactId' and text()='$1']/following-sibling::*[local-name()='version']" "$pom" &>/dev/null; then
+      found+=("$pom")
+    fi
+  done
+  POMS=(${found[@]})
+  unset found
+  export POMS
+}
+
 # In the given directory ($1),
 #   find and update all pom.xmls' dependencies on the given artifact ($2) to the given version ($3)
 # ex: update_all_poms_dependency google-cloud-java google-cloud-shared-dependencies 1.2.3

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -61,7 +61,7 @@ tar -xf showcase-*
 ./gapic-showcase run &
 popd
 
-# Run showcase tests with `native` profile
+# Run showcase tests with `native` profile. Skipping ITHttpAnnotation until https://github.com/googleapis/sdk-platform-java/issues/2695 is fixed.
 pushd sdk-platform-java/showcase
 mvn test -Dtest='!com.google.showcase.v1beta1.it.ITHttpAnnotation' -Dsurefire.failIfNoSpecifiedTests=false -Pnative,-showcase -Denforcer.skip=true -ntp -B
 popd

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -16,47 +16,6 @@
 set -eo pipefail
 set -x
 
-# In the given directory ($1),
-#   update the pom.xml's dependency on the given artifact ($2) to the given version ($3)
-# ex: update_dependency google-cloud-java/google-cloud-jar-parent google-cloud-shared-dependencies 1.2.3
-function update_pom_dependency {
-  pushd "$1" || exit 1
-  xmllint --shell pom.xml &>/dev/null <<EOF
-setns x=http://maven.apache.org/POM/4.0.0
-cd .//x:artifactId[text()="$2"]
-cd ../x:version
-set $3
-save pom.xml
-EOF
-  popd || exit 1
-}
-
-# Find all pom.xml files that declare a specific version for the given artifact ($1)
-function find_all_poms_with_versioned_dependency {
-  poms=($(find . -name pom.xml))
-  for pom in "${poms[@]}"; do
-    if xmllint --xpath "//*[local-name()='artifactId' and text()='$1']/following-sibling::*[local-name()='version']" "$pom" &>/dev/null; then
-      found+=("$pom")
-    fi
-  done
-  POMS=(${found[@]})
-  unset found
-  export POMS
-}
-
-# In the given directory ($1),
-#   find and update all pom.xmls' dependencies on the given artifact ($2) to the given version ($3)
-# ex: update_all_poms_dependency google-cloud-java google-cloud-shared-dependencies 1.2.3
-function update_all_poms_dependency {
-  pushd "$1" || exit 1
-  find_all_poms_with_versioned_dependency "$2"
-  for pom in $POMS; do
-    update_pom_dependency "$(dirname "$pom")" "$2" "$3"
-  done
-  git diff
-  popd || exit 1
-}
-
 function modify_shared_config() {
   xmllint --shell pom.xml <<EOF
   setns x=http://maven.apache.org/POM/4.0.0
@@ -106,21 +65,5 @@ popd
 pushd sdk-platform-java/showcase
 mvn test -Dtest='!com.google.showcase.v1beta1.it.ITHttpAnnotation' -Dsurefire.failIfNoSpecifiedTests=false -Pnative,-showcase -Denforcer.skip=true -ntp -B
 popd
-
-### Round 3
-# Update the shared-dependencies version in google-cloud-jar-parent
-git clone "https://github.com/googleapis/google-cloud-java.git" --depth=1
-update_all_poms_dependency google-cloud-java google-cloud-shared-dependencies "$SHARED_DEPS_VERSION"
-
-### Round 4
-# Run the updated java-shared-dependencies BOM against google-cloud-java integration tests
-cd google-cloud-java
-source ./.kokoro/common.sh
-RETURN_CODE=0
-setup_application_credentials
-setup_cloud "$MODULES_UNDER_TEST"
-run_graalvm_tests "$MODULES_UNDER_TEST"
-# Exit must occur in google-cloud-java directory to correctly destroy IT resources
-#exit "$RETURN_CODE"
 
 exit $RETURN_CODE

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -53,7 +53,7 @@ pushd sdk-platform-java/showcase/gapic-showcase
 SHOWCASE_VERSION=$(mvn help:evaluate -Dexpression=gapic-showcase.version -q -DforceStdout)
 popd
 
-### Start showcase server
+# Start showcase server
 mkdir -p /usr/src/showcase
 curl --location https://github.com/googleapis/gapic-showcase/releases/download/v"${SHOWCASE_VERSION}"/gapic-showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz --output /usr/src/showcase/showcase-"${SHOWCASE_VERSION}"-linux-amd64.tar.gz
 pushd /usr/src/showcase/
@@ -61,6 +61,7 @@ tar -xf showcase-*
 ./gapic-showcase run &
 popd
 
+# Run showcase tests with `native` profile
 pushd sdk-platform-java/showcase
 mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
 popd

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -64,7 +64,7 @@ popd
 
 # Run showcase tests with `native` profile
 pushd sdk-platform-java/showcase
-mvn test -Pnative,-showcase -Denforcer.skip=true -Dtest="!com.google.showcase.v1beta1.it.ITHttpAnnotation" -Dsurefire.failIfNoSpecifiedTests=false -ntp -B
+mvn test -Dtest='!com.google.showcase.v1beta1.it.ITHttpAnnotation' -Dsurefire.failIfNoSpecifiedTests=false -Pnative,-showcase -Denforcer.skip=true -ntp -B
 popd
 
 ### Round 3

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -31,6 +31,19 @@ EOF
   popd || exit 1
 }
 
+# In the given directory ($1),
+#   find and update all pom.xmls' dependencies on the given artifact ($2) to the given version ($3)
+# ex: update_all_poms_dependency google-cloud-java google-cloud-shared-dependencies 1.2.3
+function update_all_poms_dependency {
+  pushd "$1" || exit 1
+  find_all_poms_with_versioned_dependency "$2"
+  for pom in $POMS; do
+    update_pom_dependency "$(dirname "$pom")" "$2" "$3"
+  done
+  git diff
+  popd || exit 1
+}
+
 function modify_shared_config() {
   xmllint --shell pom.xml <<EOF
   setns x=http://maven.apache.org/POM/4.0.0

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -16,6 +16,20 @@
 set -eo pipefail
 set -x
 
+# In the given directory ($1),
+#   update the pom.xml's dependency on the given artifact ($2) to the given version ($3)
+# ex: update_dependency google-cloud-java/google-cloud-jar-parent google-cloud-shared-dependencies 1.2.3
+function update_pom_dependency {
+  pushd "$1" || exit 1
+  xmllint --shell pom.xml &>/dev/null <<EOF
+setns x=http://maven.apache.org/POM/4.0.0
+cd .//x:artifactId[text()="$2"]
+cd ../x:version
+set $3
+save pom.xml
+EOF
+  popd || exit 1
+}
 
 function modify_shared_config() {
   xmllint --shell pom.xml <<EOF

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -97,14 +97,6 @@
             <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <configuration>
-            <ignoredDependencies>${ignoredDependencies},io.grpc:grpc-protobuf-lite,org.hamcrest:hamcrest,org.hamcrest:hamcrest-core,com.google.errorprone:error_prone_annotations,org.openjdk.jmh:jmh-generator-annprocess,com.google.api.grpc:grpc-google-cloud-spanner-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1,javax.annotation:javax.annotation-api,io.opencensus:opencensus-impl,org.graalvm.sdk:graal-sdk,io.grpc:grpc-googleapis,io.grpc:grpc-rls,com.google.api.grpc:proto-google-cloud-spanner-executor-v1,com.google.api.grpc:grpc-google-cloud-spanner-executor-v1</ignoredDependencies>
-<!--            <ignoredDependencies>${ignoredDependencies}</ignoredDependencies>-->
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -101,7 +101,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
-            <ignoredDependencies>${ignoredDependencies}</ignoredDependencies>
+            <ignoredDependencies>${ignoredDependencies},io.grpc:grpc-protobuf-lite,org.hamcrest:hamcrest,org.hamcrest:hamcrest-core,com.google.errorprone:error_prone_annotations,org.openjdk.jmh:jmh-generator-annprocess,com.google.api.grpc:grpc-google-cloud-spanner-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1,com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1,javax.annotation:javax.annotation-api,io.opencensus:opencensus-impl,org.graalvm.sdk:graal-sdk,io.grpc:grpc-googleapis,io.grpc:grpc-rls,com.google.api.grpc:proto-google-cloud-spanner-executor-v1,com.google.api.grpc:grpc-google-cloud-spanner-executor-v1</ignoredDependencies>
+<!--            <ignoredDependencies>${ignoredDependencies}</ignoredDependencies>-->
           </configuration>
         </plugin>
       </plugins>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -59,7 +59,7 @@
 
   <properties>
     <surefire.version>3.2.5</surefire.version>
-    <graal-sdk.version>22.3.5</graal-sdk.version>
+    <graal-sdk.version>24.0.1</graal-sdk.version>
   </properties>
 
   <dependencyManagement>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -64,6 +64,7 @@
     <native-maven-plugin.version>0.10.2</native-maven-plugin.version>
     <junit-vintage-engine.version>5.10.3</junit-vintage-engine.version>
     <opentest4j.version>1.3.0</opentest4j.version>
+    <ignoredDependencies>org.graalvm.sdk:nativeimage</ignoredDependencies>
   </properties>
 
   <dependencyManagement>
@@ -94,6 +95,13 @@
             <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
             <autoReleaseAfterClose>false</autoReleaseAfterClose>
             <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoredDependencies>${ignoredDependencies}</ignoredDependencies>
           </configuration>
         </plugin>
       </plugins>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -59,7 +59,7 @@
 
   <properties>
     <graal-sdk.version>24.0.2</graal-sdk.version>
-    <surefire.version>3.3.0</surefire.version>
+    <surefire.version>3.3.1</surefire.version>
     <graal-sdk-nativeimage.version>24.0.2</graal-sdk-nativeimage.version>
     <native-maven-plugin.version>0.10.2</native-maven-plugin.version>
     <junit-vintage-engine.version>5.10.3</junit-vintage-engine.version>


### PR DESCRIPTION
Also verified locally with java-kms ([logs](https://gist.github.com/mpeddada1/ab78ad6de53126ad637759540a5b0078)). 

Noting two significant changes in PR:
- ~~- The `ITHttpAnnotation` test is marked as skipped in the showcase downstream check until https://github.com/googleapis/sdk-platform-java/issues/2695 is fixed.~~ https://github.com/googleapis/sdk-platform-java/issues/2695 has been fixed so we proceeded to keep this test in.
- The downstream java-spanner check is failing due to the recently added module `org.graalvm.sdk:nativeimage` being unaccounted for in the `ignoredDependencies` section of java-spanner's `maven-dependency-plugin`. We plan temporarily mark this check as optional to proceed with the update and include `org.graalvm.sdk:nativeimage` in the maven-dependency-plugin once `sdk-platform-java-config` has been updated in the repo. See https://github.com/googleapis/java-shared-config/pull/815#issuecomment-2086565890 for context. 
