### PR TITLE
chore: lift temp autovalue vertion pin for renovate.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,12 +15,6 @@
   "packageRules": [
     {
       "packagePatterns": [
-        "^com.google.auto.value:"
-      ],
-      "enabled": false
-    },
-    {
-      "packagePatterns": [
         "*"
       ],
       "semanticCommitType": "deps",


### PR DESCRIPTION
This reverts temporary renovate rule to stop updates from https://github.com/googleapis/java-shared-config/pull/800 for autovalue now that beam [2.57.0](https://github.com/apache/beam/releases/tag/v2.57.0) is out.