### PR TITLE
chore: update graalvm jdk 11 image to Graalvm for JDK 17 community image

### DIFF
--- a/.cloudbuild/graalvm-a.Dockerfile
+++ b/.cloudbuild/graalvm-a.Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-community:17.0.9-ol9
-
+FROM ghcr.io/graalvm/graalvm-community:17.0.9-ol7
 RUN gu install native-image && \
     yum update -y && \
     yum install -y wget unzip git && \

--- a/.cloudbuild/graalvm-a.Dockerfile
+++ b/.cloudbuild/graalvm-a.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-22.3.3-b1
+FROM ghcr.io/graalvm/graalvm-community:17.0.9-ol9
 
 RUN gu install native-image && \
     yum update -y && \

--- a/.cloudbuild/graalvm-a.yaml
+++ b/.cloudbuild/graalvm-a.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"11.0.20\"", "GraalVM CE 22.3.3"]
+    expectedError: ["openjdk version \"17.0.9\"", "GraalVM CE 17.0.9"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]


### PR DESCRIPTION
-  Update to use graalvm-community images (https://github.com/graalvm/container/pkgs/container/graalvm-community is the new publishing location).