### PR TITLE
fix: address terraform installation failure by updating hashicorp baseurl

### DIFF
--- a/.cloudbuild/hashicorp.repo
+++ b/.cloudbuild/hashicorp.repo
@@ -1,13 +1,13 @@
 [hashicorp]
 name=Hashicorp Stable - $basearch
-baseurl=https://rpm.releases.hashicorp.com/RHEL/8/$basearch/stable
+baseurl=https://rpm.releases.hashicorp.com/RHEL/9/$basearch/stable
 enabled=1
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg
 
 [hashicorp-test]
 name=Hashicorp Test - $basearch
-baseurl=https://rpm.releases.hashicorp.com/RHEL/8/$basearch/test
+baseurl=https://rpm.releases.hashicorp.com/RHEL/9/$basearch/test
 enabled=0
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg

--- a/.cloudbuild/hashicorp.repo
+++ b/.cloudbuild/hashicorp.repo
@@ -7,7 +7,7 @@ gpgkey=https://rpm.releases.hashicorp.com/gpg
 
 [hashicorp-test]
 name=Hashicorp Test - $basearch
-baseurl=https://archive.releases.hashicorp.com/RHEL/7/x$basearch/stable/
+baseurl=https://archive.releases.hashicorp.com/RHEL/7/x$basearch/test/
 enabled=0
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg

--- a/.cloudbuild/hashicorp.repo
+++ b/.cloudbuild/hashicorp.repo
@@ -1,13 +1,13 @@
 [hashicorp]
 name=Hashicorp Stable - $basearch
-baseurl=https://rpm.releases.hashicorp.com/RHEL/7/$basearch/stable
+baseurl=https://archive.releases.hashicorp.com/RHEL/7/$basearch/stable/
 enabled=1
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg
 
 [hashicorp-test]
 name=Hashicorp Test - $basearch
-baseurl=https://rpm.releases.hashicorp.com/RHEL/7/$basearch/test
+baseurl=https://archive.releases.hashicorp.com/RHEL/7/x$basearch/stable/
 enabled=0
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg

--- a/.cloudbuild/hashicorp.repo
+++ b/.cloudbuild/hashicorp.repo
@@ -7,7 +7,7 @@ gpgkey=https://rpm.releases.hashicorp.com/gpg
 
 [hashicorp-test]
 name=Hashicorp Test - $basearch
-baseurl=https://archive.releases.hashicorp.com/RHEL/7/x$basearch/test/
+baseurl=https://archive.releases.hashicorp.com/RHEL/7/$basearch/test/
 enabled=0
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg

--- a/.cloudbuild/hashicorp.repo
+++ b/.cloudbuild/hashicorp.repo
@@ -1,13 +1,13 @@
 [hashicorp]
 name=Hashicorp Stable - $basearch
-baseurl=https://archive.releases.hashicorp.com/RHEL/7/$basearch/stable/
+baseurl=https://rpm.releases.hashicorp.com/RHEL/8/$basearch/stable
 enabled=1
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg
 
 [hashicorp-test]
 name=Hashicorp Test - $basearch
-baseurl=https://archive.releases.hashicorp.com/RHEL/7/$basearch/test/
+baseurl=https://rpm.releases.hashicorp.com/RHEL/8/$basearch/test
 enabled=0
 gpgcheck=1
 gpgkey=https://rpm.releases.hashicorp.com/gpg

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -66,4 +66,6 @@ pushd sdk-platform-java/showcase
 mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
 popd
 
+echo "hello"
+
 exit $RETURN_CODE

--- a/.kokoro/presubmit/downstream-build.sh
+++ b/.kokoro/presubmit/downstream-build.sh
@@ -66,6 +66,4 @@ pushd sdk-platform-java/showcase
 mvn test -Pnative,-showcase -Denforcer.skip=true -ntp -B
 popd
 
-echo "hello"
-
 exit $RETURN_CODE


### PR DESCRIPTION
For https://github.com/googleapis/java-shared-config/pull/874

This PR updates the hashicorp baseurl to https://rpm.releases.hashicorp.com/RHEL/8/ to address the following error:
```
One of the configured repositories failed (Hashicorp Stable - x86_64)
. . .
The command '/bin/sh -c yum -y install terraform' returned a non-zero code: 
```
According to https://www.hashicorp.com/official-packaging-guide, only RHEL 8 and 9 are supported.