### PR TITLE
deps: update com.google.auto.value:auto-value-annotations to 1.11.0

### DIFF
--- a/.kokoro/java-storage-v2.9.3-expected-flattened-dependencies.txt
+++ b/.kokoro/java-storage-v2.9.3-expected-flattened-dependencies.txt
@@ -8,7 +8,7 @@ com.google.api:gax:jar:2.18.2:compile
 com.google.apis:google-api-services-storage:jar:v1-rev20220705-1.32.1:compile
 com.google.auth:google-auth-library-credentials:jar:1.7.0:compile
 com.google.auth:google-auth-library-oauth2-http:jar:1.7.0:compile
-com.google.auto.value:auto-value-annotations:jar:1.10.4:compile
+com.google.auto.value:auto-value-annotations:jar:1.11.0:compile
 com.google.cloud:google-cloud-core-http:jar:2.8.0:compile
 com.google.cloud:google-cloud-core:jar:2.8.0:compile
 com.google.code.findbugs:jsr305:jar:3.0.2:compile

--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -26,7 +26,7 @@
     <site.installationModule>${project.artifactId}</site.installationModule>
     <report.jxr.inherited>false</report.jxr.inherited>
     <skipITs>true</skipITs>
-    <auto-value.version>1.10.4</auto-value.version>
+    <auto-value.version>1.11.0</auto-value.version>
     <docRoot>/java/docs/reference/</docRoot>
   </properties>
 


### PR DESCRIPTION
This PR updates `com.google.auto.value:auto-value-annotations` to 1.11.0 to address the enforcer plugin issues observed in https://github.com/googleapis/sdk-platform-java/pull/3104#issuecomment-2292285314

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce) on project gax-grpc: 
Error:  Rule 2: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps failed with message:
Error:  Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Error:  Require upper bound dependencies error for com.google.auto.value:auto-value-annotations:1.10.4 paths to dependency are:
Error:  +-com.google.api:gax-grpc:2.51.1-SNAPSHOT
Error:    +-com.google.api:api-common:2.34.1-SNAPSHOT
Error:      +-com.google.auto.value:auto-value-annotations:1.10.4 (managed) <-- com.google.auto.value:auto-value-annotations:1.10.4
Error:  and
Error:  +-com.google.api:gax-grpc:2.51.1-SNAPSHOT
Error:    +-com.google.auth:google-auth-library-oauth2-http:1.24.1
Error:      +-com.google.auto.value:auto-value-annotations:1.10.4 (managed) <-- com.google.auto.value:auto-value-annotations:1.10.4
Error:  and
Error:  +-com.google.api:gax-grpc:2.51.1-SNAPSHOT
Error:    +-io.grpc:grpc-googleapis:1.66.0 [runtime]
Error:      +-io.grpc:grpc-xds:1.66.0 [runtime] (managed) <-- io.grpc:grpc-xds:1.66.0 [runtime]
Error:        +-com.google.auto.value:auto-value-annotations:1.10.4 [runtime] (managed) <-- com.google.auto.value:auto-value-annotations:1.11.0 [runtime]
```