### PR TITLE
chore: add options.logging in cloud build trigger configs

### DIFF
--- a/.cloudbuild/cloudbuild-test-a.yaml
+++ b/.cloudbuild/cloudbuild-test-a.yaml
@@ -32,3 +32,5 @@ steps:
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-a-build" ]
 
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/cloudbuild-test-b.yaml
+++ b/.cloudbuild/cloudbuild-test-b.yaml
@@ -31,3 +31,6 @@ steps:
     entrypoint: bash
     args: [ './.kokoro/presubmit/downstream-build.sh' ]
     waitFor: [ "graalvm-b-build" ]
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -43,6 +43,8 @@ steps:
       [ "-i", "gcr.io/cloud-devrel-public-resources/graalvm_b:${_JAVA_SHARED_CONFIG_VERSION}", "--config", ".cloudbuild/graalvm-b.yaml", "-v" ]
     waitFor: [ "graalvm-b-build" ]
 
+options:
+  logging: CLOUD_LOGGING_ONLY
 
 images:
   - gcr.io/cloud-devrel-public-resources/graalvm_a:${_JAVA_SHARED_CONFIG_VERSION}


### PR DESCRIPTION
Emulating solution in https://github.com/googleapis/sdk-platform-java/pull/3223 to address the following error in newly created cloudbuild triggers:

```
Your build failed to run: generic::invalid_argument: if 'build.service_account' is specified, the build must either (a) specify 'build.logs_bucket', (b) use the REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option, or (c) use either CLOUD_LOGGING_ONLY / NONE logging options
```
