### PR TITLE
feat: Maven profile for Airlock

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -383,9 +383,11 @@
     </plugins>
     <extensions>
       <extension>
-        <!-- Enables "artifactregistry://" URL scheme (go/airlock/howto_maven).
-           Extensions cannot be included in profiles (
-            https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms) -->
+        <!--
+          Enables the "artifactregistry://" URL scheme (go/airlock/howto_maven).
+          Note that Maven extensions cannot be included in profiles (
+          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
+        -->
         <groupId>com.google.cloud.artifactregistry</groupId>
         <artifactId>artifactregistry-maven-wagon</artifactId>
         <version>2.2.3</version>

--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -381,6 +381,16 @@
         </executions>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <!-- Enables "artifactregistry://" URL scheme (go/airlock/howto_maven).
+           Extensions cannot be included in profiles (
+            https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms) -->
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.3</version>
+      </extension>
+    </extensions>
   </build>
 
   <reporting>
@@ -657,6 +667,37 @@
       <properties>
         <maven.compiler.release>8</maven.compiler.release>
       </properties>
+    </profile>
+    <profile>
+      <!-- Profile to use Airlock (go/airlock/howto_maven). Disabled by default. -->
+      <id>airlock-trusted</id>
+      <repositories>
+        <repository>
+          <id>airlock</id>
+          <name>Airlock</name>
+          <url>artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>central</id>
+          <!-- Disable default Maven Central -->
+          <name>Maven Central remote repository</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
b/356854847

I confirmed the behavior by locally installing the java-shared-config (` T=$(mktemp -d) && rm -rf $T/* && mvn -Dmaven.repo.local=$T install`) and created an example project that inherits the pom.xml (https://gist.github.com/suztomo/afaa743fdcfbd86d79369d8d9bfc591e):

```
  <parent>
    <groupId>com.google.cloud</groupId>
    <artifactId>google-cloud-shared-config</artifactId>
    <version>1.11.3</version>
  </parent>
...

  <dependencies>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>33.3.1-jre</version>
    </dependency>
...
```

I ran the Maven command. I observed that the dependencies come from the specified artifact registry URL:

```
~/airlock-use-example $  mvn -Dmaven.repo.local=$T clean install -DskipTests -Pairlock-trusted  -Dcheckstyle.skip 
...
Downloading from airlock: artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.pom
[INFO] Initializing Credentials...
[INFO] Application Default Credentials unavailable.
[INFO] Using credentials retrieved from gcloud.
[INFO] Refreshing Credentials...
Downloaded from airlock: artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.pom (2.1 kB at 603 B/s)
Downloading from airlock: artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar
Downloaded from airlock: artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted/org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar (232 kB at 94 kB/s)
```

(checker-qual is a dependency of guava)