### PR TITLE
ci: Maven profile for Artifact Registry release

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -381,18 +381,6 @@
         </executions>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <!--
-          Enables the "artifactregistry://" URL scheme (go/airlock/howto_maven).
-          Note that Maven extensions cannot be included in profiles (
-          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
-        -->
-        <groupId>com.google.cloud.artifactregistry</groupId>
-        <artifactId>artifactregistry-maven-wagon</artifactId>
-        <version>2.2.3</version>
-      </extension>
-    </extensions>
   </build>
 
   <reporting>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -134,7 +134,6 @@
 
           mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
               -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
-          See
           -->
       <id>release-gcp-artifact-registry</id>
       <activation>
@@ -148,6 +147,10 @@
           <id>gcp-artifact-registry-repository</id>
           <url>${artifact-registry-url}</url>
         </repository>
+        <snapshotRepository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </snapshotRepository>
       </distributionManagement>
     </profile>
     <profile>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -81,32 +81,75 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.7.0</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>false</autoReleaseAfterClose>
-            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
+    <extensions>
+      <extension>
+        <!--
+          Enables the "artifactregistry://" URL scheme in Artifact Registry (Airlock and ExitGate).
+          Note that Maven extensions cannot be included in profiles (
+          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
+        -->
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.3</version>
+      </extension>
+    </extensions>
   </build>
   <profiles>
+    <profile>
+      <!-- By default, we release artifacts to Sonatype, which requires
+          nexus-staging-maven-plugin. -->
+      <id>release-sonatype</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nexus-staging-maven-plugin</artifactId>
+              <version>1.7.0</version>
+              <extensions>true</extensions>
+              <configuration>
+                <serverId>ossrh</serverId>
+                <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+          this release-gcp-artifact-registry profile:
+
+          mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+              -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+          See
+          -->
+      <id>release-gcp-artifact-registry</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+      </properties>
+      <distributionManagement>
+        <repository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </repository>
+      </distributionManagement>
+    </profile>
     <profile>
       <id>release</id>
       <activation>


### PR DESCRIPTION
b/369172374. Example usage:

```
mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
```

My test using an Artifact Registry instance worked good: http://gpaste/5996553914548224.
