### PR TITLE
ci: sync-repo-settings.yaml to point to java-graalvm-ci-prod

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -49,8 +49,8 @@ branchProtectionRules:
     - "build (11, java-bigtable, javadoc)"
     - "javadoc-with-doclet (java-bigtable)"
     - "cla/google"
-    - "graalvm-presubmit-shared-config-a (cloud-devrel-kokoro-resources)"
-    - "graalvm-presubmit-shared-config-b (cloud-devrel-kokoro-resources)"
+    - "graalvm-presubmit-shared-config-a (java-graalvm-ci-prod)"
+    - "graalvm-presubmit-shared-config-b (java-graalvm-ci-prod)"
 - pattern: java7
   # Can admins overwrite branch protection.
   # Defaults to `true`


### PR DESCRIPTION
The required checks are not recognized as required checks after we changed the GCP projects.

![image](https://github.com/user-attachments/assets/cc095978-346b-463b-a208-9e6ccd660a19)
