### PR TITLE
fix: revert Maven profile for Artifact Registry release

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -381,6 +381,18 @@
         </executions>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <!--
+          Enables the "artifactregistry://" URL scheme (go/airlock/howto_maven).
+          Note that Maven extensions cannot be included in profiles (
+          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
+        -->
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.3</version>
+      </extension>
+    </extensions>
   </build>
 
   <reporting>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -81,78 +81,32 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
   <build>
-    <extensions>
-      <extension>
-        <!--
-          Enables the "artifactregistry://" URL scheme in Artifact Registry (Airlock and ExitGate).
-          Note that Maven extensions cannot be included in profiles (
-          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
-        -->
-        <groupId>com.google.cloud.artifactregistry</groupId>
-        <artifactId>artifactregistry-maven-wagon</artifactId>
-        <version>2.2.3</version>
-      </extension>
-    </extensions>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.7.0</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
   <profiles>
-    <profile>
-      <!-- By default, we release artifacts to Sonatype, which requires
-          nexus-staging-maven-plugin. -->
-      <id>release-sonatype</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.sonatype.plugins</groupId>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <version>1.7.0</version>
-              <extensions>true</extensions>
-              <configuration>
-                <serverId>ossrh</serverId>
-                <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-                <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-        <plugins>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
-          this release-gcp-artifact-registry profile:
-
-          mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
-              -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
-          -->
-      <id>release-gcp-artifact-registry</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-        <artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
-      </properties>
-      <distributionManagement>
-        <repository>
-          <id>gcp-artifact-registry-repository</id>
-          <url>${artifact-registry-url}</url>
-        </repository>
-        <snapshotRepository>
-          <id>gcp-artifact-registry-repository</id>
-          <url>${artifact-registry-url}</url>
-        </snapshotRepository>
-      </distributionManagement>
-    </profile>
     <profile>
       <id>release</id>
       <activation>


### PR DESCRIPTION
Reverts googleapis/java-shared-config#936

Fix error in release job:
```
[ERROR] No plugin found for prefix 'nexus-staging' in the current project and in the plugin groups [org.apache.maven.plugins, org.codehaus.mojo] available from the repositories [local (/root/.m2/repository), central ([https://repo.maven.apache.org/maven2](https://www.google.com/url?q=https://repo.maven.apache.org/maven2&sa=D))] -> [Help 1]
```

The job succeeds in [#732](https://fusion2.corp.google.com/ci/kokoro/prod:cloud-devrel%2Fclient-libraries%2Fjava%2Fjava-shared-config%2Frelease%2Fstage/activity/48e7e202-e4ec-45a9-9b85-56668d85fca6/log)
