### PR TITLE
fix: fixed the profile for Artifact Registry deployment

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -381,18 +381,6 @@
         </executions>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <!--
-          Enables the "artifactregistry://" URL scheme (go/airlock/howto_maven).
-          Note that Maven extensions cannot be included in profiles (
-          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
-        -->
-        <groupId>com.google.cloud.artifactregistry</groupId>
-        <artifactId>artifactregistry-maven-wagon</artifactId>
-        <version>2.2.3</version>
-      </extension>
-    </extensions>
   </build>
 
   <reporting>

--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -99,14 +99,62 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
+    <extensions>
+      <extension>
+        <!--
+          Enables the "artifactregistry://" URL scheme (go/airlock/howto_maven).
+          Note that Maven extensions cannot be included in profiles (
+          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
+        -->
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.3</version>
+      </extension>
+    </extensions>
   </build>
   <profiles>
+    <profile>
+      <!-- By default, we release artifacts to Sonatype, which requires
+          nexus-staging-maven-plugin. -->
+      <id>release-sonatype</id>
+      <activation>
+        <property>
+          <!-- Only when we use the release-gcp-artifact-registry profile,
+          which comes with artifact-registry-url property, this profile is
+          turned off. -->
+          <name>!artifact-registry-url</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+          this release-gcp-artifact-registry profile:
+          mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+              -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+          -->
+      <id>release-gcp-artifact-registry</id>
+      <properties>
+        <artifact-registry-url>artifactregistry://undefined-artifact-registry-url-value</artifact-registry-url>
+      </properties>
+      <distributionManagement>
+        <repository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </repository>
+        <snapshotRepository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
     <profile>
       <id>release</id>
       <activation>


### PR DESCRIPTION
Defining the profile to publish artifacts to Artifact Registry.

The previous (reverted) attempt in https://github.com/googleapis/java-shared-config/pull/936 was wrong in that it missed this point when I used `<activeByDefault>true</activeByDefault>`:

> This profile will automatically be active for all builds unless another profile in the same POM is activated using one of the previously described methods.

from https://maven.apache.org/guides/introduction/introduction-to-profiles.html.

This pull request now turns on the release-sonatype profile unless the `artifact-registry-url` property is defined. The property artifact-registry-url is only used for Artifact Registry publication.

# Experiment

The java-shared-config repository was able to publish the artifacts to my Artifact Registry:

mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
  -P=-release-staging-repository -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...

http://gpaste/5275049054175232


