### PR TITLE
feat: update GraalVM image B to GraalVM for JDK 23

### DIFF
--- a/.cloudbuild/graalvm-b.Dockerfile
+++ b/.cloudbuild/graalvm-b.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-22.3.3-b1
+FROM ghcr.io/graalvm/graalvm-community:23.0.1-ol9-20241015
 
 RUN gu install native-image && \
     yum update -y && \

--- a/.cloudbuild/graalvm-b.Dockerfile
+++ b/.cloudbuild/graalvm-b.Dockerfile
@@ -14,9 +14,11 @@
 
 FROM ghcr.io/graalvm/graalvm-community:23.0.1-ol9-20241015
 
-RUN gu install native-image && \
-    yum update -y && \
-    yum install -y wget unzip git && \
+# native-image comes out of the box
+RUN native-image --version
+
+RUN microdnf update -y oraclelinux-release-el9 && \
+    microdnf install -y wget unzip git && \
     # Install maven
     wget -q https://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.zip -O /tmp/maven.zip && \
     unzip /tmp/maven.zip -d /tmp/maven && \
@@ -28,20 +30,22 @@ ENV PATH $PATH:/usr/local/lib/maven/bin
 
 # Install gcloud SDK
 COPY google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
-RUN yum install -y google-cloud-sdk
+RUN microdnf install -y google-cloud-sdk
 
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install docker
-RUN yum install -y docker-engine docker-cli
+# See also https://docs.docker.com/engine/install/rhel/#set-up-the-repository
+COPY docker-ce.repo /etc/yum.repos.d/docker-ce.repo
+RUN microdnf install -y docker-ce docker-ce-cli
 
 # Install terraform
 # See also https://www.hashicorp.com/official-packaging-guide
 COPY hashicorp.repo /etc/yum.repos.d/hashicorp.repo
-RUN yum -y install terraform
+RUN microdnf -y install terraform
 
 # Install jq
-RUN yum -y install jq
+RUN microdnf -y install jq
 
 WORKDIR /workspace

--- a/.cloudbuild/graalvm-b.yaml
+++ b/.cloudbuild/graalvm-b.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"17.0.8\"", "GraalVM CE 22.3.3"]
+    expectedError: ["openjdk version \"23.0.1\"", "GraalVM CE 23.0.1"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]


### PR DESCRIPTION
This is part of the effort to introduce GraalVM for JDK 23. Graal-image-b as of now supports GraalVM for JDK 17, which is not being supported anymore and expected to be replaced with support for JDK 21 and 23.

Adjustments necessary in sdk-platform-java were made in https://github.com/googleapis/sdk-platform-java/pull/3574

BEGIN_COMMIT_OVERRIDE
feat: update GraalVM image B to GraalVM for JDK 23 
END_COMMIT_OVERRIDE