### PR TITLE
chore: remove artifactregistry-maven-wagon

### DIFF
--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -99,18 +99,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <extensions>
-      <extension>
-        <!--
-          Enables the "artifactregistry://" URL scheme (go/airlock/howto_maven).
-          Note that Maven extensions cannot be included in profiles (
-          https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profiles-in-poms)
-        -->
-        <groupId>com.google.cloud.artifactregistry</groupId>
-        <artifactId>artifactregistry-maven-wagon</artifactId>
-        <version>2.2.4</version>
-      </extension>
-    </extensions>
   </build>
   <profiles>
     <profile>


### PR DESCRIPTION
Removing artifactregistry-maven-wagon extension declaration in favor of the extensions.xml file in Google3. There's no need to declare the extension in the shared config (native-image-shared-config.xml).
