### PR TITLE
fix: declare Maven plugin versions

### DIFF
--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -97,6 +97,11 @@
             <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.3</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,27 @@
     <module>java-shared-config</module>
   </modules>
 
-  <!-- Do not deploy the aggregator POM -->
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.11.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.1.3</version>
+        <!-- Do not deploy the aggregator POM -->
         <configuration>
           <skip>true</skip>
         </configuration>


### PR DESCRIPTION
This addresses the following messages:

- 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing.
- 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing.
- 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing.
