### PR TITLE
ci: Build with Airlock as required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -51,6 +51,7 @@ branchProtectionRules:
     - "cla/google"
     - "graalvm-presubmit-shared-config-a (java-graalvm-ci-prod)"
     - "graalvm-presubmit-shared-config-b (java-graalvm-ci-prod)"
+    - "Build with Airlock"
 - pattern: java7
   # Can admins overwrite branch protection.
   # Defaults to `true`


### PR DESCRIPTION
The "Build with Airlock" check now succeeds. Let's keep the status green.
