### PR TITLE
fix: introducing "flatten" profile to use the plugin

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -728,5 +728,18 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!-- Profile to use the flatten plugin. This is useful for testing
+        the availability of the dependencies in Airlock. -->
+      <id>flatten</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
The plugin is not needed in this project but it's used in the downstream Java repositories.

By specifying the profile in "Build with Airlock" check, we can ensure the required dependencies are available in Airlock. This profile is not meant to be used by the downstream repositories because they specify the flatten plugin only to the main module in each repository.

This is not actually a "fix" change. But I want a patch version release.

