### PR TITLE
feat: google-java-format version as a property

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -28,6 +28,7 @@
     <skipITs>true</skipITs>
     <auto-value.version>1.11.0</auto-value.version>
     <docRoot>/java/docs/reference/</docRoot>
+    <google-java-format.version>1.7</google-java-format.version>
   </properties>
 
   <build>
@@ -179,7 +180,7 @@
             <dependency>
               <groupId>com.google.googlejavaformat</groupId>
               <artifactId>google-java-format</artifactId>
-              <version>1.7</version>
+              <version>${google-java-format.version}</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
b/395190324. Once we declare this version as a property, then the hermetic build script can use the property value to determine the version of the google-java-format to download when it builds the container image.

```
$ JAVA_FORMAT_VERSION=$(mvn -pl java-shared-config help:evaluate -Dexpression='google-java-format.version' -q -DforceStdout)
$ echo $JAVA_FORMAT_VERSION
1.7
```

This uses https://maven.apache.org/plugins/maven-help-plugin/evaluate-mojo.html
