### PR TITLE
deps: Update maven flatten plugin to v1.7.0

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -187,7 +187,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.3.0</version>
+          <version>1.7.0</version>
           <executions>
             <!-- enable flattening -->
             <execution>


### PR DESCRIPTION
This dep wasn't being updated by renovate bot for some reason. Manually update it for now as I am trying to use the `-Dflatten.skip` flag (introduced in v1.6.0).