### PR TITLE
fix: use recommended variable expansion syntax

### DIFF
--- a/.cloudbuild/cloudbuild-test-c.yaml
+++ b/.cloudbuild/cloudbuild-test-c.yaml
@@ -15,16 +15,22 @@
 timeout: 7200s # 2 hours
 substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.15.3' # {x-version-update:google-cloud-shared-config:current}
-  _COMMIT_HASH_TAG: infrastructure-public-image-$SHORT_SHA
 
 steps:
   # GraalVM C build
-- name: 'bash'
-  env: 
-  script: |
-    #!/usr/bin/env bash
-    echo "${_COMMIT_HASH_TAG}"
+  - name: gcr.io/cloud-builders/docker
+    args: ["build", "-t", "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_c:${_JAVA_SHARED_CONFIG_VERSION}", "--file", "graalvm-c.Dockerfile", "."]
+    dir: .cloudbuild
+    id: graalvm-c-build
+    waitFor: ["-"]
+  - name: gcr.io/gcp-runtimes/structure_test
+    args:
+      ["-i", "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_c:${_JAVA_SHARED_CONFIG_VERSION}", "--config", ".cloudbuild/graalvm-c.yaml", "-v"]
+    waitFor: ["graalvm-c-build"]
+  - name: us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_c:${_JAVA_SHARED_CONFIG_VERSION}
+    entrypoint: bash
+    args: [ './.kokoro/presubmit/downstream-build.sh' ]
+    waitFor: [ "graalvm-c-build" ]
 
 options:
   logging: CLOUD_LOGGING_ONLY
-  automapSubstitutions: true

--- a/.cloudbuild/cloudbuild-test-c.yaml
+++ b/.cloudbuild/cloudbuild-test-c.yaml
@@ -15,7 +15,7 @@
 timeout: 7200s # 2 hours
 substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.15.3' # {x-version-update:google-cloud-shared-config:current}
-  _COMMIT_HASH_TAG: infrastructure-public-image-${SHORT_SHA}
+  _COMMIT_HASH_TAG: infrastructure-public-image-$SHORT_SHA
 
 steps:
   # GraalVM C build

--- a/.cloudbuild/cloudbuild-test-c.yaml
+++ b/.cloudbuild/cloudbuild-test-c.yaml
@@ -15,22 +15,14 @@
 timeout: 7200s # 2 hours
 substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.15.3' # {x-version-update:google-cloud-shared-config:current}
+  _COMMIT_HASH_TAG: infrastructure-public-image-${SHORT_SHA}
 
 steps:
   # GraalVM C build
-  - name: gcr.io/cloud-builders/docker
-    args: ["build", "-t", "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_c:${_JAVA_SHARED_CONFIG_VERSION}", "--file", "graalvm-c.Dockerfile", "."]
-    dir: .cloudbuild
-    id: graalvm-c-build
-    waitFor: ["-"]
-  - name: gcr.io/gcp-runtimes/structure_test
-    args:
-      ["-i", "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_c:${_JAVA_SHARED_CONFIG_VERSION}", "--config", ".cloudbuild/graalvm-c.yaml", "-v"]
-    waitFor: ["graalvm-c-build"]
-  - name: us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_c:${_JAVA_SHARED_CONFIG_VERSION}
-    entrypoint: bash
-    args: [ './.kokoro/presubmit/downstream-build.sh' ]
-    waitFor: [ "graalvm-c-build" ]
+- name: 'bash'
+  script: |
+    #!/usr/bin/env bash
+    echo "${_COMMIT_HASH_TAG}"
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/.cloudbuild/cloudbuild-test-c.yaml
+++ b/.cloudbuild/cloudbuild-test-c.yaml
@@ -20,9 +20,11 @@ substitutions:
 steps:
   # GraalVM C build
 - name: 'bash'
+  env: 
   script: |
     #!/usr/bin/env bash
     echo "${_COMMIT_HASH_TAG}"
 
 options:
   logging: CLOUD_LOGGING_ONLY
+  automapSubstitutions: true

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -16,7 +16,7 @@ timeout: 7200s # 2 hours
 substitutions:
   _JAVA_SHARED_CONFIG_VERSION: '1.15.3' # {x-version-update:google-cloud-shared-config:current}
   _IMAGE_REPOSITORY: us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing
-  _COMMIT_HASH_TAG: infrastructure-public-image-$SHORT_SHA
+  _COMMIT_HASH_TAG: infrastructure-public-image-${SHORT_SHA}
 steps:
   # GraalVM A build
   - name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
Fixes [failed build job](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/24b765ea-92c7-4a49-8875-b3e4c04ec39e?e=13803378&invt=Abu1uQ&mods=monitoring_api_prod&project=java-graalvm-ci-prod)

```
Your build failed to run: invalid build: invalid image name "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:infrastructure-public-image-$SHORT_SHA": could not parse reference: us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:infrastructure-public-image-$SHORT_SHA
```


### Confirmation
 - Using `$SHORT_SHA` does not expand the variable in the substitution section as confirmed in [this job](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/e25c12b1-fb5e-4ce8-9fa7-3c8cdc0b7c91?project=java-graalvm-ci-prod&e=13803378&mods=monitoring_api_prod&invt=Abu1zw), associated with https://github.com/googleapis/java-shared-config/pull/1016/commits/e94b2594acce75bcbe413dda390a8364c6d99ce0, **which produces the wrong value `infrastructure-public-image-$SHORT_SHA`**
 - Using `${SHORT_SHA}` does expand as confirmed in [this job](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/edd9232d-875f-453a-a7b3-64c94e759ea5?project=java-graalvm-ci-prod&e=13803378&mods=monitoring_api_prod&invt=Abu10A), associated with https://github.com/googleapis/java-shared-config/pull/1016/commits/760d82604978d48534a3a3a50fc7d7d36182071b, **which produces the value `infrastructure-public-image-760d826`**