### PR TITLE
feat: update GraalVM image B to GraalVM for JDK 24

### DIFF
--- a/.cloudbuild/graalvm-b.Dockerfile
+++ b/.cloudbuild/graalvm-b.Dockerfile
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-community:23.0.2-ol9-20250121
+FROM ghcr.io/graalvm/graalvm-community:24.0.1-ol8-20250415
 
 # native-image comes out of the box
 RUN native-image --version
 
-RUN microdnf update -y oraclelinux-release-el9 && \
-    microdnf install -y wget unzip git && \
+RUN microdnf install -y wget unzip git && \
     # Install maven
     wget -q https://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.zip -O /tmp/maven.zip && \
     unzip /tmp/maven.zip -d /tmp/maven && \

--- a/.cloudbuild/graalvm-b.Dockerfile
+++ b/.cloudbuild/graalvm-b.Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ghcr.io/graalvm/graalvm-community:24.0.1-ol8-20250415
+FROM ghcr.io/graalvm/graalvm-community:24.0.1-ol9-20250415
 
 # native-image comes out of the box
 RUN native-image --version
 
-RUN microdnf update -y oraclelinux-release-el8 && \
+RUN microdnf update -y oraclelinux-release-el9 && \
     microdnf install -y wget unzip git && \
     # Install maven
     wget -q https://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.zip -O /tmp/maven.zip && \

--- a/.cloudbuild/graalvm-b.Dockerfile
+++ b/.cloudbuild/graalvm-b.Dockerfile
@@ -17,7 +17,8 @@ FROM ghcr.io/graalvm/graalvm-community:24.0.1-ol8-20250415
 # native-image comes out of the box
 RUN native-image --version
 
-RUN microdnf install -y wget unzip git && \
+RUN microdnf update -y oraclelinux-release-el8 && \
+    microdnf install -y wget unzip git && \
     # Install maven
     wget -q https://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.zip -O /tmp/maven.zip && \
     unzip /tmp/maven.zip -d /tmp/maven && \

--- a/.cloudbuild/graalvm-b.yaml
+++ b/.cloudbuild/graalvm-b.yaml
@@ -17,7 +17,7 @@ commandTests:
   - name: "version"
     command: ["java", "-version"]
     # java -version outputs to stderr...
-    expectedError: ["openjdk version \"23.0.2\"", "GraalVM CE 23.0.2"]
+    expectedError: ["openjdk version \"24.0.1\"", "GraalVM CE 24.0.1"]
   - name: "maven"
     command: ["mvn", "-version"]
     expectedOutput: ["Apache Maven 3.9.4"]


### PR DESCRIPTION
update GraalVM image B to JDK 24, remove unsupported GraalVM 23.