### PR TITLE
deps: latest maven-deploy-plugin 3.1.4

### DIFF
--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -224,6 +224,11 @@
           <artifactId>maven-install-plugin</artifactId>
           <version>3.1.3</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.4</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
Without explicitly declaring maven-deploy-plugin, it's possible that some release job uses its 2.x version, which doesn't recognize "local::file:${local_staging_dir}" parameter.

cl/766852134
