### PR TITLE
deps: upgrade graal-sdk to 24.2.2

### DIFF
--- a/native-image-shared-config/pom.xml
+++ b/native-image-shared-config/pom.xml
@@ -58,7 +58,7 @@
   </licenses>
 
   <properties>
-    <graal-sdk.version>24.2.1</graal-sdk.version>
+    <graal-sdk.version>24.2.2</graal-sdk.version>
     <surefire.version>3.5.2</surefire.version>
     <graal-sdk-nativeimage.version>24.2.2</graal-sdk-nativeimage.version>
     <native-maven-plugin.version>0.10.6</native-maven-plugin.version>


### PR DESCRIPTION
Upgrading the version property to match graal-sdk-nativeimage version. 
