### PR TITLE
ci: sdk-platform-java-config in google-cloud-java in downstream checks

### DIFF
--- a/.kokoro/client-library-check-doclet.sh
+++ b/.kokoro/client-library-check-doclet.sh
@@ -76,13 +76,14 @@ scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 cd ${scriptDir}/..
 
 # Make artifacts available for 'mvn validate' at the bottom
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
+mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q --no-transfer-progress
 
 # Get version of doclet used to generate Cloud RAD for javadoc testing with the doclet below
+rm -rf java-docfx-doclet
 git clone https://github.com/googleapis/java-docfx-doclet.git
 pushd java-docfx-doclet/third_party/docfx-doclet-143274
 git checkout 1.9.0
-mvn package -Dmaven.test.skip=true
+mvn package -Dmaven.test.skip=true -B -V --no-transfer-progress
 
 # work from the root directory
 popd
@@ -101,27 +102,31 @@ fi
 echo "Version: ${JAVA_SHARED_CONFIG_VERSION}"
 
 # Update java-shared-config in sdk-platform-java-config
-git clone "https://github.com/googleapis/sdk-platform-java.git" --depth=1
-pushd sdk-platform-java
-SDK_PLATFORM_JAVA_CONFIG_VERSION=$(get_current_version_from_versions_txt versions.txt "google-cloud-shared-dependencies")
-RELEASED_SHARED_DEPENDENCIES_VERSION=$(get_released_version_from_versions_txt versions.txt "google-cloud-shared-dependencies")
-echo "This is the SDK_PLATFORM_JAVA_CONFIG_VERSION: ${SDK_PLATFORM_JAVA_CONFIG_VERSION}"
-echo "This is the RELEASED_SHARED_DEPENDENCIES_VERSION: ${RELEASED_SHARED_DEPENDENCIES_VERSION}"
-pushd sdk-platform-java-config
+rm -rf google-cloud-java
+# Find the latest tag matching v* and use it
+LATEST_TAG=$(git ls-remote --tags https://github.com/googleapis/google-cloud-java.git | grep 'refs/tags/v' | sort -k2,2 -V | tail -n 1 | awk '{print $2}' | sed 's|refs/tags/||')
+echo "Cloning google-cloud-java at tag: ${LATEST_TAG}"
+git clone "https://github.com/googleapis/google-cloud-java.git" -b "${LATEST_TAG}" --depth=1
+pushd google-cloud-java/sdk-platform-java
+SDK_PLATFORM_JAVA_CONFIG_VERSION=$(sed -e 's/xmlns=".*"//' sdk-platform-java-config/pom.xml | xmllint --xpath '/project/version/text()' -)
 
+pushd sdk-platform-java-config
 # Use released version of google-cloud-shared-dependencies to avoid verifying SNAPSHOT changes.
 replace_java_shared_config_version "${JAVA_SHARED_CONFIG_VERSION}"
-replace_java_shared_dependencies_version "${RELEASED_SHARED_DEPENDENCIES_VERSION}"
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
+echo "The diff in sdk-platform-java-config:"
+git --no-pager diff
+echo "--------"
+mvn install "-DskipTests=true" "-Dmaven.javadoc.skip=true" "-Dgcloud.download.skip=true" "-Dcheckstyle.skip=true" -B -V -q --no-transfer-progress
 popd
 
 # Check javadoc generation with the doclet
+rm -rf "${REPO}"
 git clone "https://github.com/googleapis/${REPO}.git" --depth=1
 
 pushd ${REPO}
 replace_sdk_platform_java_config_version "${SDK_PLATFORM_JAVA_CONFIG_VERSION}"
 
-mvn clean -B -ntp \
+mvn clean -B --no-transfer-progress \
     -P docFX \
     -DdocletPath="${docletPath}" \
     -Dclirr.skip=true \

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -100,21 +100,28 @@ fi
 echo "Version: ${JAVA_SHARED_CONFIG_VERSION}"
 
 # Update java-shared-config in sdk-platform-java-config
-git clone "https://github.com/googleapis/sdk-platform-java.git" --depth=1
-pushd sdk-platform-java
-SDK_PLATFORM_JAVA_CONFIG_VERSION=$(get_current_version_from_versions_txt versions.txt "google-cloud-shared-dependencies")
-RELEASED_SHARED_DEPENDENCIES_VERSION=$(get_released_version_from_versions_txt versions.txt "google-cloud-shared-dependencies")
-pushd sdk-platform-java-config
+rm -rf google-cloud-java
+# Find the latest tag matching v* and use it
+LATEST_TAG=$(git ls-remote --tags https://github.com/googleapis/google-cloud-java.git | grep 'refs/tags/v' | sort -k2,2 -V | tail -n 1 | awk '{print $2}' | sed 's|refs/tags/||')
+echo "Cloning google-cloud-java at tag: ${LATEST_TAG}"
+git clone "https://github.com/googleapis/google-cloud-java.git" -b "${LATEST_TAG}" --depth=1
+pushd google-cloud-java/sdk-platform-java
+SDK_PLATFORM_JAVA_CONFIG_VERSION=$(sed -e 's/xmlns=".*"//' sdk-platform-java-config/pom.xml | xmllint --xpath '/project/version/text()' -)
 
+pushd sdk-platform-java-config
 # Use released version of google-cloud-shared-dependencies to avoid verifying SNAPSHOT changes.
 replace_java_shared_config_version "${JAVA_SHARED_CONFIG_VERSION}"
-replace_java_shared_dependencies_version "${RELEASED_SHARED_DEPENDENCIES_VERSION}"
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V -q
+echo "The diff in sdk-platform-java-config:"
+git --no-pager diff
+echo "--------"
+mvn install "-DskipTests=true" "-Dmaven.javadoc.skip=true" "-Dgcloud.download.skip=true" "-Dcheckstyle.skip=true" -B -V -q
 popd
+
 popd
 
 # Check this BOM against a few java client libraries
 # java-bigquery
+rm -rf "${REPO}"
 if [ -z "${REPO_TAG}" ]; then
   git clone "https://github.com/googleapis/${REPO}.git" --depth=1
 else
@@ -122,6 +129,9 @@ else
 fi
 
 pushd ${REPO}
+
+# Force update dependencies in target repo
+sed -i 's/mvn install/mvn install -U/' .kokoro/dependencies.sh
 
 # If using an older version of java-storage, continue replacing java-shared-config version otherwise replace
 # the version of sdk-platform-java-config.

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -130,9 +130,6 @@ fi
 
 pushd ${REPO}
 
-# Force update dependencies in target repo
-sed -i 's/mvn install/mvn install -U/' .kokoro/dependencies.sh
-
 # If using an older version of java-storage, continue replacing java-shared-config version otherwise replace
 # the version of sdk-platform-java-config.
 if [ "${REPO_TAG}" == "v2.9.3" ] && [ "${REPO}" == "java-storage" ]; then

--- a/settings.xml
+++ b/settings.xml
@@ -19,14 +19,5 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
     <mirrors>
-        <mirror>
-            <!-- Google's Maven Central mirror for Americas
-             https://maven-central.storage.googleapis.com/index.html
-            -->
-            <id>google-maven-central</id>
-            <name>GCS Maven Central mirror</name>
-            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-            <mirrorOf>central</mirrorOf>
-        </mirror>
     </mirrors>
 </settings>


### PR DESCRIPTION
The downstream checks have been failing:

<img width="908" height="353" alt="image" src="https://github.com/user-attachments/assets/1a199904-2690-47de-b365-5f288c6967d7" />

The sdk-platform-java repository has moved to the sdk-platform-java
folder in the google-cloud-java repository. The downstream checks that
use sdk-platform-java-config needs to adjust the location; otherwise it continues
to use the old GAX code, which recently got new methods.

b/504981788